### PR TITLE
Introduce xunit.TestDiscoverer

### DIFF
--- a/TestDiscoverer/App.config
+++ b/TestDiscoverer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/TestDiscoverer/ConsoleDiagnosticsMessageVisitor.cs
+++ b/TestDiscoverer/ConsoleDiagnosticsMessageVisitor.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Xunit.Abstractions;
+
+namespace Xunit.TestDiscoverer
+{
+    internal class ConsoleDiagnosticsMessageVisitor : TestMessageVisitor<IDiagnosticMessage>
+    {
+        protected override bool Visit(IDiagnosticMessage diagnosticMessage)
+        {
+            Console.Error.WriteLine(diagnosticMessage.Message);
+            return true;
+        }
+    }
+}

--- a/TestDiscoverer/Program.cs
+++ b/TestDiscoverer/Program.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Xunit.Abstractions;
+
+namespace Xunit.TestDiscoverer
+{
+    /// <summary>
+    /// Finds (but does not run) all XUnit tests in the given assembly.
+    /// </summary>
+    internal class Program
+    {
+        internal static void Main(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                PrintUsage();
+                return;
+            }
+
+            // TODO: Other command-line options (e.g. output format, include/exclude traits)
+            // TODO: If args[0] is a directory name instead of a filename or contains wildcards, then search for all applicable assemblies.
+            DiscoverTests(args[0], TestCaseDiscovered);
+        }
+
+        private static bool DiscoverTests(string assemblyFileName, Action<ITestCase> testCaseDiscoveredAction)
+        {
+            try
+            {
+                // Note: We do not use shadowCopy because that creates a new AppDomain which can cause
+                // assembly load failures with delay-signed or "fake signed" assemblies.
+                using (var controller = new XunitFrontController(
+                    assemblyFileName: assemblyFileName,
+                    shadowCopy: false,
+                    diagnosticMessageSink: new ConsoleDiagnosticsMessageVisitor())
+                    )
+                using (var discoveryVisitor = new TestCaseDisoveryVisitor(testCaseDiscoveredAction))
+                {
+                    controller.Find(includeSourceInformation: false, messageSink: discoveryVisitor, discoveryOptions: TestFrameworkOptions.ForDiscovery());
+                    discoveryVisitor.Finished.WaitOne();
+                }
+            }
+            catch (Exception ex)
+            {
+                PrintException(ex);
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool AcceptFilter(ITestCase testCase)
+        {
+            // TODO: More filtering (e.g. include/exclude traits)
+            return testCase.SkipReason == null;
+        }
+
+        private static void TestCaseDiscovered(ITestCase testCase)
+        {
+            if (AcceptFilter(testCase))
+            {
+                // Note: DisplayName can be overridden in the source, but it defaults to the fully-qualified
+                // name of the test method.
+                //Console.WriteLine(testCase.DisplayName);
+
+                Console.WriteLine($"Class:{testCase.TestMethod.TestClass.Class.Name} Method:{testCase.TestMethod.Method.Name}");
+            }
+        }
+
+        private static void PrintException(Exception ex)
+        {
+            for (; ex != null; ex = ex.InnerException)
+            {
+                Console.Error.WriteLine($"{ex.GetType().FullName}: {ex.Message}");
+            }
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Discovers all the XUnit test cases in an assembly.");
+            Console.WriteLine("Usage:");
+            Console.WriteLine("TestDiscoverer <assemblyPath>");
+        }
+    }
+}

--- a/TestDiscoverer/Properties/AssemblyInfo.cs
+++ b/TestDiscoverer/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestDiscoverer")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("TestDiscoverer")]
+[assembly: AssemblyCopyright("Copyright © Microsoft 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6c564825-1c70-4c65-b4ca-774203333ecb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestDiscoverer/TestCaseDisoveryVisitor.cs
+++ b/TestDiscoverer/TestCaseDisoveryVisitor.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Xunit.Abstractions;
+
+namespace Xunit.TestDiscoverer
+{
+    internal class TestCaseDisoveryVisitor : TestMessageVisitor<IDiscoveryCompleteMessage>
+    {
+        private readonly Action<ITestCase> _testDiscoveredAction;
+
+        public TestCaseDisoveryVisitor(Action<ITestCase> testDiscoveredAction)
+        {
+            _testDiscoveredAction = testDiscoveredAction;
+        }
+
+        protected override bool Visit(ITestCaseDiscoveryMessage testCaseDiscovered)
+        {
+            _testDiscoveredAction(testCaseDiscovered.TestCase);
+            return true;
+        }
+    }
+}

--- a/TestDiscoverer/packages.config
+++ b/TestDiscoverer/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.1.0-beta3-build3029" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.1.0-beta3-build3029" targetFramework="net452" />
+  <package id="xunit.runner.utility" version="2.1.0-beta3-build3029" targetFramework="net452" />
+</packages>

--- a/TestDiscoverer/xunit.TestDiscoverer.csproj
+++ b/TestDiscoverer/xunit.TestDiscoverer.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6C564825-1C70-4C65-B4CA-774203333ECB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>XUnit.TestDiscoverer</RootNamespace>
+    <AssemblyName>xunit.TestDiscoverer</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3029, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0-beta3-build3029\lib\portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3029, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0-beta3-build3029\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.runner.utility.desktop, Version=2.1.0.3029, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.1.0-beta3-build3029\lib\net35\xunit.runner.utility.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConsoleDiagnosticsMessageVisitor.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestCaseDisoveryVisitor.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/xunit.performance.sln
+++ b/xunit.performance.sln
@@ -7,7 +7,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.performance", "xunit.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.performance.analysis", "xunit.performance.analysis\xunit.performance.analysis.csproj", "{E114F722-0353-4BCE-A1BE-A6D729FDEACD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SImplePerfTests", "samples\SimplePerfTests\SimplePerfTests.csproj", "{F92BE283-3DC0-49E5-8FD1-E1F5FADD4ADC}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimplePerfTests", "samples\SimplePerfTests\SimplePerfTests.csproj", "{F92BE283-3DC0-49E5-8FD1-E1F5FADD4ADC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.TestDiscoverer", "TestDiscoverer\xunit.TestDiscoverer.csproj", "{6C564825-1C70-4C65-B4CA-774203333ECB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{F92BE283-3DC0-49E5-8FD1-E1F5FADD4ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F92BE283-3DC0-49E5-8FD1-E1F5FADD4ADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F92BE283-3DC0-49E5-8FD1-E1F5FADD4ADC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C564825-1C70-4C65-B4CA-774203333ECB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C564825-1C70-4C65-B4CA-774203333ECB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C564825-1C70-4C65-B4CA-774203333ECB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C564825-1C70-4C65-B4CA-774203333ECB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
@Chrisboh Here's a simple XUnit test discoverer. Run it on a test assembly and it will spit out all the test methods. Lots of room for improvement. e.g. adding Traits filtering; accepting a list of unit test assemblies or wildcards; specifying the output format.

@ericeil I realize this isn't specific to 'performance', so perhaps xunit-performance isn't the best place. If you'd rather it not be in the xunit-performance repo, I understand. I'm open to suggestions for alternatives or I could just host it on my own repo. Please let me know what you think.
