### PR TITLE
Simplified nuspecs

### DIFF
--- a/FullBuild.cmd
+++ b/FullBuild.cmd
@@ -21,11 +21,11 @@ bump the build number on BuildSemanticVersion below.
 setlocal
 
 set BuildAssemblyVersion=1.0.0.0
-set BuildSemanticVersion=1.0.0-alpha-build0003
+set BuildSemanticVersion=1.0.0-alpha-build0004
 
 echo Building version %BuildSemanticVersion% NuGet packages.
 echo WARNING: Some source files will be modified during this build.
-echo WARNING: Pleae be careful not to check in those modifications.
+echo WARNING: Please be careful not to check in those modifications.
 
 msbuild.exe /m /nologo /t:CI /v:m /fl xunit.performance.msbuild
 

--- a/src/xunit.performance.core.nuspec
+++ b/src/xunit.performance.core.nuspec
@@ -11,28 +11,20 @@ Contains the design time assembly for xunit.performance. It contains the Benchma
 
 Supported platforms:
 - Desktop .NET 4.6
-- .NET Core (Universal Windows Apps 10+, DNX Core 5+)
+- .NET Core (Universal Windows Apps 10+)
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
     <licenseUrl>https://github.com/Microsoft/xunit-performance/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <group targetFramework="net46">
-        <dependency id="xunit.core" version="2.1.0-beta4-build3109" />
-      </group>
       <group targetFramework="dotnet">
-        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="xunit.extensibility.core" version="2.1.0-beta4-build3109" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="xunit.performance.core\bin\Release\xunit.performance.core.dll" target="lib\net46\" />
-    <file src="xunit.performance.core\bin\Release\xunit.performance.core.pdb" target="lib\net46\" />
-    <file src="xunit.performance.core\bin\Release\xunit.performance.core.xml" target="lib\net46\" />
     <file src="xunit.performance.core\bin\Release\xunit.performance.core.dll" target="lib\dotnet\" />
     <file src="xunit.performance.core\bin\Release\xunit.performance.core.pdb" target="lib\dotnet\" />
     <file src="xunit.performance.core\bin\Release\xunit.performance.core.xml" target="lib\dotnet\" />

--- a/src/xunit.performance.core/AllocatesAttribute.cs
+++ b/src/xunit.performance.core/AllocatesAttribute.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.Xunit.Performance
 {
     /// <summary>
-    /// Allows specification of whether a [Benchmark] method allocates new objects from the GC heap.  
+    /// Allows specification of whether a <see cref="BenchmarkAttribute"/> method allocates new objects from the GC heap.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class AllocatesAttribute : Attribute

--- a/src/xunit.performance.core/Properties/AssemblyInfo.cs
+++ b/src/xunit.performance.core/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Resources;
-using System.Reflection;
+﻿using System.Reflection;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -7,4 +6,3 @@ using System.Reflection;
 [assembly: AssemblyTitle("xunit.performance Core")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
-[assembly: NeutralResourcesLanguage("en")]

--- a/src/xunit.performance.core/project.json
+++ b/src/xunit.performance.core/project.json
@@ -1,8 +1,7 @@
 ﻿{
-  "version": "99.99.99-dev",
   "supports": {
-    "net46.app": { },
-    "uwp.10.0.app": { }
+    "net46.app": {},
+    "uwp.10.0.app": {}
   },
   "dependencies": {
     "Microsoft.NETCore": "5.0.0",

--- a/src/xunit.performance.execution.DotNetCore/project.json
+++ b/src/xunit.performance.execution.DotNetCore/project.json
@@ -1,5 +1,4 @@
 ﻿{
-  "version": "99.99.99-dev",
   "supports": {
     "net46.app": {},
     "uwp.10.0.app": {}

--- a/src/xunit.performance.execution.nuspec
+++ b/src/xunit.performance.execution.nuspec
@@ -11,19 +11,13 @@ Contains the libraries necessary for running xunit performance tests. Note: You 
 
 Supported platforms:
 - Desktop .NET 4.6
-- .NET Core (Universal Windows Apps 10+, DNX Core 5+)
+- .NET Core (Universal Windows Apps 10+)
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
     <licenseUrl>https://github.com/Microsoft/xunit-performance/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <group targetFramework="net46">
-        <dependency id="xunit.abstractions" version="2.0.0" />
-        <dependency id="xunit.extensibility.core" version="2.1.0-beta4-build3109" />
-        <dependency id="xunit.extensibility.execution" version="2.1.0-beta4-build3109" />
-        <dependency id="Microsoft.DotNet.xunit.performance.core" version="[99.99.99-dev]" />
-      </group>
       <group targetFramework="dotnet">
         <dependency id="Microsoft.DotNet.xunit.performance.core" version="[99.99.99-dev]" />
         <dependency id="System.Collections" version="4.0.10" />
@@ -31,8 +25,6 @@ Supported platforms:
         <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
         <dependency id="System.Linq" version="4.0.0" />
         <dependency id="System.Reflection" version="4.0.10" />
-        <dependency id="System.Reflection.TypeExtensions" version="4.0.0" />
-        <dependency id="System.Resources.ResourceManager" version="4.0.0" />
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />
         <dependency id="System.Threading" version="4.0.10" />

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Xunit.Performance
                 default: return () => TestMethod.Invoke(testClassInstance, TestMethodArguments);
             }
 
-            var invokerFactory = typeof(BenchmarkTestInvoker).GetMethod(invokerFactoryName, BindingFlags.Instance | BindingFlags.NonPublic);
+            var invokerFactory = typeof(BenchmarkTestInvoker).GetTypeInfo().GetDeclaredMethod(invokerFactoryName);
             var invokerFactoryInstance = invokerFactory.MakeGenericMethod(types);
 
             return (Func<object>)invokerFactoryInstance.Invoke(this, args);

--- a/src/xunit.performance.execution/Properties/AssemblyInfo.cs
+++ b/src/xunit.performance.execution/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Resources;
-using System.Reflection;
+﻿using System.Reflection;
 
 [assembly: Xunit.Sdk.PlatformSpecificAssembly]
 
@@ -13,4 +12,3 @@ using System.Reflection;
 #endif
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
-[assembly: NeutralResourcesLanguage("en")]

--- a/xunit.performance.msbuild
+++ b/xunit.performance.msbuild
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <NuspecFiles Include="src\*.nuspec" />
-    <ProjectJsonFiles Include="src\*\project.json" />
+    <!--<ProjectJsonFiles Include="src\*\project.json" />-->
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageSources)' == '' ">
     <PackageSource Include="https://nuget.org/api/v2/" />
@@ -62,7 +62,7 @@
     <RegexReplace
         Pattern='99\.99\.99-dev'
         Replacement='$(BuildSemanticVersion)'
-        Files='@(NuspecFiles);@(ProjectJsonFiles)'
+        Files='@(NuspecFiles)'
         Condition=" '$(BuildSemanticVersion)' != '' "/>
   </Target>
 


### PR DESCRIPTION
Several things here:
1. Removed the "net46" target from the nuspecs. I found out that VS 2015 prefers to use "dotnet", even when targeting the 4.6 desktop framework. I think, from what I've read, that VS 2013 may use the "net46" moniker (if you have the 4.6 multi-targeting pack installed). For now, we'll call that an unsupported scenario.
2. Removed dependency on System.Reflection.TypeExtensions which is not available on DNX projects. This required a one-line change to BenchmarkTestInvoker to use the portable reflection API.
3. Removed reference on System.Resources which was being pulled in only for the "NeutralResourcesLanguage" assembly attribute.
4. Removed semver information from project.json files. I followed what xunit had done here, but it doesn't add any value - the .nuspec has the semantic version in it (and it gets removed if project.json gets rewritten anyway).
