### PR TITLE
Fix Instructions Retired metric

### DIFF
--- a/samples/SimplePerfTests/Properties/AssemblyInfo.cs
+++ b/samples/SimplePerfTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Xunit.Performance;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -37,3 +38,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: MeasureInstructionsRetired]

--- a/src/xunit.performance.metrics/InstructionsRetiredMetricDiscoverer.cs
+++ b/src/xunit.performance.metrics/InstructionsRetiredMetricDiscoverer.cs
@@ -7,7 +7,9 @@ using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using Microsoft.Diagnostics.Tracing.Session;
 using Microsoft.Xunit.Performance.Sdk;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Xunit.Abstractions;
 
 namespace Microsoft.Xunit.Performance
@@ -17,23 +19,36 @@ namespace Microsoft.Xunit.Performance
         const int DefaultInterval = 100000; // Instructions per event.
         const string CounterName = "InstructionRetired";
 
+        readonly int _profileSource;
+
+        public InstructionsRetiredMetricDiscoverer()
+        {
+            ProfileSourceInfo info;
+            if (TraceEventProfileSources.GetInfo().TryGetValue(CounterName, out info))
+                _profileSource = info.ID;
+            else
+                _profileSource = -1;
+        }
+
         public IEnumerable<PerformanceMetric> GetMetrics(IAttributeInfo metricAttribute)
         {
-            if (TraceEventProfileSources.GetInfo().ContainsKey(CounterName))
+            if (_profileSource != -1)
             {
                 var interval = (int)(metricAttribute.GetConstructorArguments().FirstOrDefault() ?? DefaultInterval);
-                yield return new InstructionsRetiredMetric(interval);
+                yield return new InstructionsRetiredMetric(interval, _profileSource);
             }
         }
 
         private class InstructionsRetiredMetric : PerformanceMetric
         {
             private readonly int _interval;
+            private readonly int _profileSource;
 
-            public InstructionsRetiredMetric(int interval)
+            public InstructionsRetiredMetric(int interval, int profileSource)
                 : base("InstRetired", "Instructions Retired", PerformanceMetricUnits.Count)
             {
                 _interval = interval;
+                _profileSource = profileSource;
             }
 
             public override IEnumerable<ProviderInfo> ProviderInfo
@@ -42,8 +57,7 @@ namespace Microsoft.Xunit.Performance
                 {
                     yield return new KernelProviderInfo()
                     {
-                        Keywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile),
-                        StackKeywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile)
+                        Keywords = unchecked((ulong)(KernelTraceEventParser.Keywords.PMCProfile | KernelTraceEventParser.Keywords.Profile)),
                     };
                     yield return new CpuCounterInfo()
                     {
@@ -53,34 +67,59 @@ namespace Microsoft.Xunit.Performance
                 }
             }
 
+            //
+            // We create just one PerformanceMetricEvaluator per PerformanceEvaluationContext (which represents a single ETW session).
+            // This lets us track state (the counter sampling interval) across test cases.  It would be nice if PerformanceMetricEvaluationContext
+            // made this easier, but for now we'll just track the relationship with a ConditionalWeakTable.
+            //
+            // TODO: consider better support for persistent state in PerformanceMetricEvaluationContext.
+            //
+            private static ConditionalWeakTable<PerformanceMetricEvaluationContext, InstructionsRetiredEvaluator> s_evaluators = 
+                new ConditionalWeakTable<PerformanceMetricEvaluationContext, InstructionsRetiredEvaluator>();
+
             public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
             {
-                return new InstructionsRetiredEvaluator(context, _interval);
+                var evaluator = s_evaluators.GetOrCreateValue(context);
+                evaluator.Initialize(context, _profileSource);
+                return evaluator;
             }
         }
 
         private class InstructionsRetiredEvaluator : PerformanceMetricEvaluator
         {
-            private readonly PerformanceMetricEvaluationContext _context;
+            private PerformanceMetricEvaluationContext _context;
+            private int _profileSource;
             private int _interval;
             private long _count;
 
-            public InstructionsRetiredEvaluator(PerformanceMetricEvaluationContext context, int interval)
+            internal void Initialize(PerformanceMetricEvaluationContext context, int profileSource)
             {
-                _context = context;
-                _interval = interval;
-                _context.TraceEventSource.Kernel.PerfInfoSetInterval += PerfInfoSetInterval;
-                _context.TraceEventSource.Kernel.PerfInfoPMCSample += PerfInfoPMCSample;
+                lock (this)
+                {
+                    if (_context == null)
+                    {
+                        context.TraceEventSource.Kernel.PerfInfoCollectionStart += PerfInfoCollectionStart;
+                        context.TraceEventSource.Kernel.PerfInfoPMCSample += PerfInfoPMCSample;
+                        _context = context;
+                        _profileSource = profileSource;
+                    }
+                    else
+                    {
+                        Debug.Assert(_context == context);
+                        Debug.Assert(_profileSource == profileSource);
+                    }
+                }
             }
 
-            private void PerfInfoSetInterval(SampledProfileIntervalTraceData ev)
+            private void PerfInfoCollectionStart(SampledProfileIntervalTraceData ev)
             {
-                _interval = ev.NewInterval;
+                if (ev.SampleSource == _profileSource)
+                    _interval = ev.NewInterval;
             }
 
             private void PerfInfoPMCSample(PMCCounterProfTraceData ev)
             {
-                if (_context.IsTestEvent(ev))
+                if (ev.ProfileSource == _profileSource && _context.IsTestEvent(ev))
                     _count += _interval;
             }
 


### PR DESCRIPTION
Fixes #57.
- Tracks the sample interval correctly.  We needed to enable another kernel provider, and persist the reported interval across test cases.
- Disables stacks on these events.  These resulted in much larger ETL files.
- Correctly filter these to just the particular counter we're interested in.
