### PR TITLE
README and LICENSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ void EmptyBenchmark()
 }
 ```
 
+This may also be written as:
+
+```csharp
+[Benchmark]
+void EmptyBenchmark()
+{
+  Benchmark.Iterate(() => { /*do nothing*/ });
+}
+```
+
 The first iteration is the "warmup" iteration; all performance metrics are discarded by the result analyzer.  Subsequent iterations are measured. 
 
 ## Running benchmarks

--- a/src/xunit.performance.analysis.nuspec
+++ b/src/xunit.performance.analysis.nuspec
@@ -11,7 +11,7 @@ Contains the tools necessary for analyzing the output of xunit Performance tests
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
-    <licenseUrl>https://github.com/Microsoft/xunit-performance/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>

--- a/src/xunit.performance.nuspec
+++ b/src/xunit.performance.nuspec
@@ -16,7 +16,7 @@
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
-    <licenseUrl>https://github.com/Microsoft/xunit-performance/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>

--- a/src/xunit.performance.runner.Windows.nuspec
+++ b/src/xunit.performance.runner.Windows.nuspec
@@ -11,7 +11,7 @@ Contains the tools necessary for running xunit Performance tests in Windows usin
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
-    <licenseUrl>https://github.com/Microsoft/xunit-performance/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>


### PR DESCRIPTION
My Fork got detached from upstream (Microsoft\xunit-performance) when we made the repo public.
In the meantime, I had made a couple of trivial changes.

I just re-created the fork and now I'm merging the two changes back.

1. Add the new ```Benchmark.Iterate``` syntax to the README example.
2. Use raw.githubuser.com as the URL for LICENSE in the Nuspecs