### PR TITLE
Add test discovery to linux runner

### DIFF
--- a/dnx/src/Microsoft.DotNet.xunit.performance.runner.dnx/project.json
+++ b/dnx/src/Microsoft.DotNet.xunit.performance.runner.dnx/project.json
@@ -12,7 +12,7 @@
   "requireLicenseAcceptance": false,
 
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance.run.core": "99.99.99-dev",
+    "Microsoft.DotNet.xunit.performance.run.core": "1.0.0-alpha-build0018",
     "xunit.extensibility.execution": "2.1.0-rc2-build3176"
   },
 

--- a/src/xunit.performance.run/PerformanceTestDisoveryVisitor.cs
+++ b/src/xunit.performance.run/PerformanceTestDisoveryVisitor.cs
@@ -12,7 +12,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.Xunit.Performance
 {
-    internal class PerformanceTestDiscoveryVisitor : global::Xunit.TestMessageVisitor<IDiscoveryCompleteMessage>
+    public class PerformanceTestDiscoveryVisitor : global::Xunit.TestMessageVisitor<IDiscoveryCompleteMessage>
     {
         public readonly List<PerformanceTestInfo> Tests = new List<PerformanceTestInfo>();
         private XunitProjectAssembly _assembly;


### PR DESCRIPTION
Toyed around a bit with adding test discovery to the linux runner. I've got a base setup here, but I'm missing something that I haven't been able to figure out yet.

Using the packages created by these changes on Linux causes an assembly load error for the testAssembly.

Command I'm using:
```
xunit.performance System.IO.FileSystem.Tests.dll -verbose -runner xunit.console.netcore.exe -runnerhost corerun -runid run1 -outdir out
```
Result:
```
xunit.performance Console Runner (64-bit .NET Portable)
Copyright (C) 2015 Microsoft Corporation.

Creating output directory: perfout
Discovering tests for /home/ianha/kcorefx/System.IO.FileSystem.Tests.dll.
Error: Could not load file or assembly 'System.IO.FileSystem.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.

   at System.Reflection.RuntimeAssembly._nLoad(AssemblyName fileName, String codeBase, Evidence assemblySecurity, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, Evidence assemblySecurity, RuntimeAssembly reqAssembly, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.Assembly.Load(AssemblyName assemblyRef)
   at Xunit.Sdk.ReflectionAssemblyInfo..ctor(String assemblyFileName)
--- End of stack trace from previous location where exception was thrown ---
   at ExceptionExtensions.RethrowWithNoStackTraceLoss(Exception ex)
   at Xunit.AppDomainManager_NoAppDomain.CreateObject[TObject](AssemblyName assemblyName, String typeName, Object[] args)
   at Xunit.Xunit2Discoverer..ctor(AppDomainSupport appDomainSupport, ISourceInformationProvider sourceInformationProvider, IAssemblyInfo assemblyInfo, String assemblyFileName, String xunitExecutionAssemblyPath, String configFileName, Boolean shadowCopy, String shadowCopyFolder, IMessageSink diagnosticMessageSink, Boolean verifyAssembliesOnDisk)
   at Xunit.Xunit2..ctor(AppDomainSupport appDomainSupport, ISourceInformationProvider sourceInformationProvider, String assemblyFileName, String configFileName, Boolean shadowCopy, String shadowCopyFolder, IMessageSink diagnosticMessageSink, Boolean verifyTestAssemblyExists)
   at Xunit.XunitFrontController.CreateInnerController()
   at Xunit.XunitFrontController.get_InnerController()
   at Xunit.XunitFrontController.Find(Boolean includeSourceInformation, IMessageSink messageSink, ITestFrameworkDiscoveryOptions discoveryOptions)
   at Microsoft.Xunit.Performance.CSVMetricLogger..ctor(XunitPerformanceProject project, Program program)
   at Microsoft.Xunit.Performance.Program.GetPerformanceMetricLogger(XunitPerformanceProject project)
   at Microsoft.Xunit.Performance.ProgramCore.RunTests(XunitPerformanceProject project)
   at Microsoft.Xunit.Performance.ProgramCore.Run(String[] args)
Could not load the specified file.
   at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
```

This error is familiar, but I can't discern where/when i recognize it from. Some versioning error, maybe?

@ericeil @mellinoe thoughts?