### PR TITLE
Insert a small random delay before each measured region

### DIFF
--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -176,15 +176,19 @@ namespace Microsoft.Xunit.Performance
                     {
                         _randomDelayGenerator = new Random();
 
+                        // Very short spin, just to "warm up" the spin loop.
+                        SpinDelay(10);
+
                         for (int calibrationSpinCount = 1024; ; calibrationSpinCount *= 2)
                         {
-                            var calibrationStart = Stopwatch.GetTimestamp();
+                            var start = Stopwatch.GetTimestamp();
                             SpinDelay(calibrationSpinCount);
-                            var calibrationEnd = Stopwatch.GetTimestamp();
+                            var elapsed = Stopwatch.GetTimestamp() - start;
 
-                            if (calibrationEnd - calibrationStart >= 100)
+                            if (elapsed >= 1000)
                             {
-                                _randomDelaySpinLimit = calibrationSpinCount;
+                                // Set the limit at roughly 100 Stopwatch ticks.
+                                _randomDelaySpinLimit = (int)((100 * calibrationSpinCount) / elapsed);
                                 break;
                             }
                         }


### PR DESCRIPTION
This is to compensate for limited timer resolution.  This way, each iteration's measurement starts at a random distance (in time) from the previous clock tick, with the goal that any error due to clock resolution will be randomly distributed across iterations.  This should make it possible to get good data on much smaller measured regions than before.

Fixes #62.
