### PR TITLE
Mark all Benchmarks with a trait "Benchmark=true"

### DIFF
--- a/src/xunit.performance.core/BenchmarkAttribute.cs
+++ b/src/xunit.performance.core/BenchmarkAttribute.cs
@@ -14,8 +14,9 @@ namespace Microsoft.Xunit.Performance
     /// </summary>
     [XunitTestCaseDiscoverer("Microsoft.Xunit.Performance.BenchmarkDiscoverer", "xunit.performance.execution.{Platform}")]
     [PerformanceMetricDiscoverer("Microsoft.Xunit.Performance.BenchmarkMetricDiscoverer", "xunit.performance.metrics")]
+    [TraitDiscoverer("Microsoft.Xunit.Performance.BenchmarkDiscoverer", "xunit.performance.execution.{Platform}")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class BenchmarkAttribute : FactAttribute, IPerformanceMetricAttribute
+    public class BenchmarkAttribute : FactAttribute, IPerformanceMetricAttribute, ITraitAttribute
     {
     }
 }

--- a/src/xunit.performance.execution/BenchmarkDiscoverer.cs
+++ b/src/xunit.performance.execution/BenchmarkDiscoverer.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Microsoft.Xunit.Performance
 {
-    internal class BenchmarkDiscoverer : TheoryDiscoverer
+    internal class BenchmarkDiscoverer : TheoryDiscoverer, ITraitDiscoverer
     {
         private IMessageSink _diagnosticMessageSink;
 
@@ -54,6 +55,11 @@ namespace Microsoft.Xunit.Performance
                     yield return new BenchmarkTestCase(_diagnosticMessageSink, defaultMethodDisplay, testMethod, benchmarkAttribute, theoryCase.TestMethodArguments);
                 }
             }
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            return new[] { new KeyValuePair<string, string>("Benchmark", "true") };
         }
     }
 }


### PR DESCRIPTION
This permits filtering to just benchmarks, in test assemblies that include other kinds of tests.