### PR TITLE
Support for MinIterations

### DIFF
--- a/samples/SimplePerfTests/Calibration.cs
+++ b/samples/SimplePerfTests/Calibration.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Xunit.Performance;
+using System;
 using System.Threading;
 using Xunit;
 
@@ -42,6 +43,19 @@ namespace SimplePerfTests
                 }
             }
             return sum;
+        }
+
+        [Benchmark]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public static void Sleep(int milliseconds)
+        {
+            var ev = new ManualResetEvent(initialState: false);
+
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    ev.WaitOne(milliseconds);
         }
     }
 }

--- a/src/xunit.performance.execution/BenchmarkConfiguration.cs
+++ b/src/xunit.performance.execution/BenchmarkConfiguration.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Xunit.Performance
     internal static class BenchmarkConfiguration
     {
         public static readonly string RunId = Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_RUN_ID");
+        public static readonly int MinIteration = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MIN_ITERATION") ?? "1");
         public static readonly int MaxIteration = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_ITERATION") ?? "0");
         public static readonly int MaxTotalMilliseconds = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS") ?? "0");
         public static readonly string FileLogPath = Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_FILE_LOG_PATH");

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Xunit.Performance
                         return true;
                     }
 
-                    if (_currentIteration > 1 && _overallTimer.ElapsedMilliseconds > BenchmarkConfiguration.MaxTotalMilliseconds)
+                    if (_currentIteration > BenchmarkConfiguration.MinIteration && 
+                        _overallTimer.ElapsedMilliseconds > BenchmarkConfiguration.MaxTotalMilliseconds)
                     {
                         IterationStopReason = "MaxTime";
                         return true;

--- a/src/xunit.performance.run/ProgramCore.cs
+++ b/src/xunit.performance.run/ProgramCore.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Xunit.Performance
             };
 
             startInfo.Environment["XUNIT_PERFORMANCE_RUN_ID"] = project.RunId;
+            startInfo.Environment["XUNIT_PERFORMANCE_MIN_ITERATION"] = "10";
             startInfo.Environment["XUNIT_PERFORMANCE_MAX_ITERATION"] = "1000";
             startInfo.Environment["XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS"] = "1000";
             startInfo.Environment["COMPLUS_gcConcurrent"] = "0";

--- a/src/xunit.performance.run/xunit.performance.run.csproj
+++ b/src/xunit.performance.run/xunit.performance.run.csproj
@@ -25,7 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <UseVSHostingProcess>true</UseVSHostingProcess>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Execute for a minimum number of iterations before stopping due to any time limits.  This way longer-running tests will still produce enough data for analysis.

Fixes #91.  @ianhays 