### PR TITLE
Add MeasureGCAllocationsAttribute

### DIFF
--- a/samples/SimplePerfTests/StringThroughput.cs
+++ b/samples/SimplePerfTests/StringThroughput.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using Xunit;
 
 [MeasureGCCounts]
+[MeasureGCAllocations]
 public static class StringThroughput
 {
     #region helpers

--- a/src/xunit.performance.core/MeasureGCAllocationsAttribute.cs
+++ b/src/xunit.performance.core/MeasureGCAllocationsAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance.Sdk;
+using System;
+
+namespace Microsoft.Xunit.Performance
+{
+    /// <summary>
+    /// An attribute that is applied to a method, class, or assembly, to indicate that the performance test framework
+    /// should collect and report the total size of objects allocated on the GC heap.
+    /// </summary>
+    /// <remarks>
+    /// Note that the underlying GC events used to collect this data report samples of aggregates of object allocations.
+    /// Even if every iteration of the test allocates, many iterations may report zero allocations.  The average value collected
+    /// across all iterations should give a meaningful measure of per-iteration allocations.
+    /// </remarks>
+    [PerformanceMetricDiscoverer("Microsoft.Xunit.Performance.GCAllocationsMetricDiscoverer", "xunit.performance.metrics")]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+    public class MeasureGCAllocationsAttribute : Attribute, IPerformanceMetricAttribute
+    {
+    }
+}

--- a/src/xunit.performance.core/PerformanceMetricUnits.cs
+++ b/src/xunit.performance.core/PerformanceMetricUnits.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Xunit.Performance.Sdk
 {
@@ -25,8 +20,8 @@ namespace Microsoft.Xunit.Performance.Sdk
         public const string Milliseconds = "msec";
 
         /// <summary>
-        /// Indicates that a performance metric's value is measured in megabytes (1,048,576 bytes).
+        /// Indicates that a performance metric's value is measured in bytes.
         /// </summary>
-        public const string Megabytes = "mbyte";
+        public const string Bytes = "bytes";
     }
 }

--- a/src/xunit.performance.core/xunit.performance.core.csproj
+++ b/src/xunit.performance.core/xunit.performance.core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="BenchmarkIterator.cs" />
     <Compile Include="IPerformanceMetricAttribute.cs" />
     <Compile Include="IPerformanceMetricDiscoverer.cs" />
+    <Compile Include="MeasureGCAllocationsAttribute.cs" />
     <Compile Include="MeasureInstructionsRetired.cs" />
     <Compile Include="MeasureGCCountsAttribute.cs" />
     <Compile Include="OptimizeForBenchmarksAttribute.cs" />

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -131,6 +131,9 @@ namespace Microsoft.Xunit.Performance
 
             private IEnumerable<BenchmarkIteration> GetIterations()
             {
+                GC.Collect(2);
+                GC.WaitForPendingFinalizers();
+
                 for (_currentIteration = 0; !DoneIterating; _currentIteration++)
                 {
                     _currentIterationMeasurementStarted = false;
@@ -156,9 +159,6 @@ namespace Microsoft.Xunit.Performance
                         throw new InvalidOperationException("StartMeasurement already called for the current iteration");
 
                     _currentIterationMeasurementStarted = true;
-
-                    GC.Collect(2, GCCollectionMode.Optimized);
-                    GC.WaitForPendingFinalizers();
 
                     RandomizeMeasurementStartTime();
 

--- a/src/xunit.performance.metrics/GCAllocationsMetricDiscoverer.cs
+++ b/src/xunit.performance.metrics/GCAllocationsMetricDiscoverer.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Xunit.Performance.Sdk;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace Microsoft.Xunit.Performance
+{
+    internal class GCAllocationsMetricDiscoverer : IPerformanceMetricDiscoverer
+    {
+        public IEnumerable<PerformanceMetricInfo> GetMetrics(IAttributeInfo metricAttribute)
+        {
+            yield return new GCAllocationsMetric();
+        }
+
+        private class GCAllocationsMetric : PerformanceMetric
+        {
+            public GCAllocationsMetric()
+                : base("GCAlloc", "GC Allocations", PerformanceMetricUnits.Bytes)
+            {
+            }
+
+            public override IEnumerable<ProviderInfo> ProviderInfo
+            {
+                get
+                {
+                    yield return new UserProviderInfo()
+                    {
+                        ProviderGuid = ClrTraceEventParser.ProviderGuid,
+                        Level = TraceEventLevel.Verbose,
+                        Keywords = (ulong)ClrTraceEventParser.Keywords.GC
+                    };
+                }
+            }
+
+            public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+            {
+                return new GCAllocationsEvaluator(context);
+            }
+        }
+
+        private class GCAllocationsEvaluator : PerformanceMetricEvaluator
+        {
+            private readonly PerformanceMetricEvaluationContext _context;
+            private long _bytes;
+
+            public GCAllocationsEvaluator(PerformanceMetricEvaluationContext context)
+            {
+                _context = context;
+                context.TraceEventSource.Clr.GCAllocationTick += Clr_GCAllocationTick;
+            }
+
+            private void Clr_GCAllocationTick(GCAllocationTickTraceData ev)
+            {
+                if (_context.IsTestEvent(ev))
+                    _bytes += ev.AllocationAmount64;
+            }
+
+            public override void BeginIteration(TraceEvent beginEvent)
+            {
+                _bytes = 0;
+            }
+
+            public override double EndIteration(TraceEvent endEvent)
+            {
+                return _bytes;
+            }
+        }
+    }
+}

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="BenchmarkMetricDiscoverer.cs" />
     <Compile Include="CpuCounterInfo.cs" />
+    <Compile Include="GCAllocationsMetricDiscoverer.cs" />
     <Compile Include="InstructionsRetiredMetricDiscoverer.cs" />
     <Compile Include="GCCountMetricDiscoverer.cs" />
     <Compile Include="PerformanceMetric.cs" />


### PR DESCRIPTION
This adds a metric to track the size of allocations made on the GC heap.
Also, moves the GC trigger from being per-iteration to per-testcase.  This gives more accurate sampling of GC counts and allocations.  This may result in noisier durations, but on average they may be a more accurate representation of real performance; we'll need to gain some experience with this.

@sokket