### PR TITLE
Fixing escaping for multiple commas in csv

### DIFF
--- a/src/xunit.performance.analysis/Program.cs
+++ b/src/xunit.performance.analysis/Program.cs
@@ -286,14 +286,16 @@ namespace Microsoft.Xunit.Performance.Analysis
 
         private static string EscapeCsvString(string str)
         {
+            str.Trim('\"');
             // Escape the csv string
-            if(str.Contains("\""))
+            if (str.Contains("\""))
             {
-                str = "\"" + str.Replace("\"", "\"\"") + "\"";
+                str = str.Replace("\"", "\"\"");
             }
+            
             if (str.Contains(","))
             {
-                str = string.Format("\"{0}\"", str);
+                str = "\"\"" + str + "\"\"";
             }
             return str;
         }


### PR DESCRIPTION
Fixed a bug where the escaping logic would not take into consideration strings with multiple commas in them
@davmason @brianrob 