### PR TITLE
Lock dotnet version to unblock perf testing

### DIFF
--- a/BuildCliComponents.cmd
+++ b/BuildCliComponents.cmd
@@ -27,7 +27,7 @@ if NOT exist "%DotNet_Path%" mkdir "%DotNet_Path%"
 set DotNet_Installer_Url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "Invoke-WebRequest -Uri '%DotNet_Installer_Url%' -OutFile '%DotNet_Path%\dotnet-install.ps1'"
 echo Executing dotnet installer script %DotNet_Path%\dotnet-install.ps1
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "%DotNet_Path%\dotnet-install.ps1 -InstallDir %DotNet_Path%"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "%DotNet_Path%\dotnet-install.ps1 -InstallDir %DotNet_Path%" -Version '1.0.0-rc2-002543'
 
 if NOT exist "%DotNet%" (
   echo ERROR: Could not install dotnet cli correctly. See '%Init_Tools_Log%' for more details.

--- a/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
@@ -28,7 +28,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3*"
+          "version": "1.0.0-rc2-3002543"
         }
       }
     }

--- a/src/cli/xunit.performance.analysis.cli/project.json
+++ b/src/cli/xunit.performance.analysis.cli/project.json
@@ -26,7 +26,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3*"
+          "version": "1.0.0-rc2-3002543"
         }
       }
     }


### PR DESCRIPTION
CiBuild was downloading the 'latest' dotnet framework version, which broke our
ability to run dotnet performance tests. This PR locks in the correct version to
unblock perf testing.