### PR TITLE
Trimming cli dependencies to NETStandard.Library

### DIFF
--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.32
-set BuildSemanticVersion=1.0.0-alpha-build0032
+set BuildAssemblyVersion=1.0.0.33
+set BuildSemanticVersion=1.0.0-alpha-build0033
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
@@ -1,6 +1,6 @@
 {
   "version": "99.99.99-dev",
-  "title": "xUnit Performance Runner for .NET Core",
+  "title": "xUnit Performance analysis tool for dotnet cli",
   "description": "Contains the tools necessary for running xunit Performance tests on .NET Core (Windows, Linux, OSX, etc.)",
   "authors": [ "brianrob@microsoft.com" ],
   "owners": [ "Microsoft" ],
@@ -17,18 +17,22 @@
   "compileFiles": [
     "../../xunit.performance.analysis/Program.cs"
   ],
+  "dependencies": {
+      "Microsoft.NETCore.DotNetHostPolicy":"1.0.1-rc2-002357-00",
+      "NETStandard.Library": "1.5.0-rc2-23931",
+      "System.Linq.Parallel":"4.0.1-rc3-23928-00"
+  },
+  "__comment": "netcoreapp1.0 import and the runtime below is a hack, we need CLI to allow us to build issue reference: https://github.com/dotnet/cli/issues/2913",
   "frameworks": {
     "netstandard1.3": {
       "imports": [
         "dnxcore50",
-        "portable-net45+win8"
-      ],
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0-rc2-3002520"
-        }
-      }
+        "portable-net45+win8",
+        "netcoreapp1.0"
+      ]
     }
+  },
+  "runtimes": {
+    "win7-x64": {}
   }
 }

--- a/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
@@ -10,28 +10,26 @@
   "licenseUrl": "https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE",
   "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288859",
   "requireLicenseAcceptance": false,
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
   "dependencies": {
     "Microsoft.DotNet.xunit.performance.run.core": "99.99.99-dev",
+    "Microsoft.NETCore.DotNetHostPolicy":"1.0.1-rc2-002357-00",
+    "NETStandard.Library": "1.5.0-rc2-23931",
     "xunit.extensibility.execution": "2.1.0"
   },
-
+  "__comment": "netcoreapp1.0 import and the runtime below is a hack, we need CLI to allow us to build issue reference: https://github.com/dotnet/cli/issues/2913",
   "frameworks": {
     "netstandard1.3": {
       "imports": [
         "dnxcore50",
-        "portable-net45+win8"
-      ],
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0-rc2-3002520"
-        }
-      }
+        "portable-net45+win8",
+        "netcoreapp1.0"
+      ]
     }
+  },
+  "runtimes": {
+    "win7-x64": {}
   }
 }
-


### PR DESCRIPTION
Building executable libraries using NETStandard library since we cannot use Microsoft NetCoreApp dependencies for CoreFX

@lt72 @ericstj 