### PR TITLE
Add Linux Build and CI Support

### DIFF
--- a/BuildCliComponents.sh
+++ b/BuildCliComponents.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+######################################################################
+# Build the components of xunit.performance that support build via the
+# Dotnet CLI.
+#
+# This script will bootstrap the latest version of the CLI into the
+# tools directory prior to build.
+######################################################################
+
+######################################
+## FOR DEBUGGING ONLY
+######################################
+# set -x
+
+declare currentDir=`pwd`
+declare outputDirectory=${currentDir}/LocalPackages
+declare dotnetPath=${currentDir}/tools/bin/ubuntu
+declare dotnetCmd=${dotnetPath}/dotnet
+declare dotnetInstallerUrl=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
+declare dotnetInstallerScript=${dotnetPath}/dotnet-install.sh
+declare dotnetVersion=`cat DotNetCliVersion.txt`
+
+if ! [ -f $dotnetCmd ]
+then
+	echo Installing Dotnet CLI
+	if ! [ -f $dotnetPath ]
+	then
+		mkdir -p $dotnetPath
+	fi
+	
+	curl $dotnetInstallerUrl -o $dotnetInstallerScript
+	chmod +x $dotnetInstallerScript
+
+	$dotnetInstallerScript --version $dotnetVersion --install-dir $dotnetPath --no-path
+fi
+
+if ! [ -f $dotnetCmd ]
+then
+	echo Unable to install Dotnet CLI.  Exiting.
+	exit -1
+fi
+
+declare buildConfiguration=$1
+if [ "$buildConfiguration" == "" ]
+then
+	buildConfiguration="debug"
+fi
+
+declare nupkgCount=`ls LocalPackages/*.nupkg | wc -l`
+if [ "$nupkgCount" == "0"  ]
+then
+	echo Linux builds depend on artifacts from Windows build.  Please build on Windows first.
+	exit -1
+fi
+
+echo Building CLI-based components
+pushd ${currentDir}/src/cli/Microsoft.DotNet.xunit.performance.runner.cli > /dev/null
+$dotnetCmd restore
+$dotnetCmd build -c $buildConfiguration
+$dotnetCmd pack -c $buildConfiguration -o $outputDirectory
+popd > /dev/null
+pushd ${currentDir}/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli > /dev/null
+$dotnetCmd restore
+$dotnetCmd build -c $buildConfiguration
+$dotnetCmd pack -c $buildConfiguration -o $outputDirectory
+popd > /dev/null
+
+echo Build complete

--- a/netci.groovy
+++ b/netci.groovy
@@ -4,26 +4,77 @@ import jobs.generation.Utilities;
 
 def project = GithubProject
 def branch = GithubBranchName
+def projectFolder = Utilities.getFolderName(project) + '/' + Utilities.getFolderName(branch)
 
-// Standard build jobs
+// Windows + Linux build jobs
 
 [true, false].each { isPR ->
-    ['Debug','Release'].each { configuration ->
-        def lowerConfigurationName = configuration.toLowerCase();
-        def newJob = job(Utilities.getFullJobName(project, lowerConfigurationName, isPR)) {
-            steps {
-                batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat\" && CIBuild /${lowerConfigurationName}")
+    ['Ubuntu'].each { os ->
+        ['Debug','Release'].each { configuration ->
+
+            // Global job vars.
+            def lowerConfigurationName = configuration.toLowerCase();
+            def linuxFlowJobName = "LinuxFlow_${os}_${lowerConfigurationName}"
+
+            // Setup a Windows job to build csproj-based components.
+            def winOS = 'Windows_NT';
+            def winBuildJobName = "${winOS.toLowerCase()}_${lowerConfigurationName}";
+            def newWinJob = job(Utilities.getFullJobName(project, winBuildJobName, isPR)) {
+                steps {
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat\" && CIBuild /${lowerConfigurationName}")
+                    batchFile("C:\\Packer\\Packer.exe .\\LocalPackages.pack . LocalPackages")
+                }
             }
-        }
-        
-        Utilities.setMachineAffinity(newJob, 'Windows_NT', 'latest-or-auto')
-        Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-        Utilities.addArchival(newJob, 'msbuild.log', '', true, false)
-        if (isPR) {
-            Utilities.addGithubPRTriggerForBranch(newJob, branch, "${configuration} Build")
-        }
-        else {
-            Utilities.addGithubPushTrigger(newJob)
+
+            Utilities.setMachineAffinity(newWinJob, winOS, 'latest-or-auto')
+            Utilities.standardJobSetup(newWinJob, project, isPR, "*/${branch}")
+            Utilities.addArchival(newWinJob, 'LocalPackages.pack')
+            Utilities.addArchival(newWinJob, 'msbuild.log', '', true, false)
+
+            // Setup a Linux job to build the Linux components.
+            def fullWinBuildJobName = projectFolder + '/' + newWinJob.name
+            def linuxBuildJobName = "${os.toLowerCase()}_${lowerConfigurationName}";
+            def newLinuxJob = job(Utilities.getFullJobName(project, linuxBuildJobName, isPR)) {
+                steps {
+                    copyArtifacts(fullWinBuildJobName) {
+                        includePatterns('*.pack')
+                        buildSelector {
+                            buildNumber('\${WIN_BUILD}')
+                        }
+                    }
+
+                    shell("unpacker LocalPackages.pack .")
+                    shell("chmod +x BuildCliComponents.sh")
+                    shell("./BuildCliComponents.sh ${lowerConfigurationName}")
+                }
+
+                parameters {
+                    stringParam('WIN_BUILD', '', 'Build number to use for copying binaries for Linux build.')
+                }
+            }
+
+            Utilities.setMachineAffinity(newLinuxJob, os, 'latest-or-auto')
+            Utilities.standardJobSetup(newLinuxJob, project, isPR, "*/${branch}")
+
+            // Setup a flow job to orchestrate things.
+            def fullXunitPerformanceTestJobName = projectFolder + '/' + newLinuxJob.name
+            def newLinuxFlowJob = buildFlowJob(Utilities.getFullJobName(project, linuxFlowJobName, isPR)) {
+                buildFlow("""
+                    b = build(params, "${fullWinBuildJobName}")
+                    build(params +
+                    [WIN_BUILD: b.build.number], "${fullXunitPerformanceTestJobName}")
+                    """)
+            }
+
+            Utilities.setMachineAffinity(newLinuxFlowJob, os, 'latest-or-auto')
+            Utilities.standardJobSetup(newLinuxFlowJob, project, isPR, "*/${branch}")
+
+            if (isPR) {
+                Utilities.addGithubPRTriggerForBranch(newLinuxFlowJob, branch, "Windows / ${os} ${configuration} Build")
+            }
+            else {
+                Utilities.addGithubPushTrigger(newLinuxFlowJob)
+            }
         }
     }
 }


### PR DESCRIPTION
1. Add a new script to build the CLI based components on Linux.
2. Update the CI jobs to build on Ubuntu in addition to Windows.

NOTE: This change was tested in the citest branch - it won't take effect on the CI jobs for this PR.