### PR TITLE
Plumb build configuration to BuildCliComponents.cmd

### DIFF
--- a/BuildCliComponents.cmd
+++ b/BuildCliComponents.cmd
@@ -13,6 +13,9 @@ tools directory prior to build.
 :main
 setlocal
 
+set BuildConfiguration=%1%
+if "%BuildConfiguration%"=="" set BuildConfiguration=Debug
+
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\bin\dotnet.exe
 
@@ -40,13 +43,13 @@ if NOT exist "%DotNet%" (
 echo Building CLI-based components
 pushd %~dp0src\cli\Microsoft.DotNet.xunit.performance.runner.cli
 call %DotNet% restore
-call %DotNet% build -c Release
-call %DotNet% pack -c Release -o %OutputDirectory%
+call %DotNet% build -c %BuildConfiguration%
+call %DotNet% pack -c %BuildConfiguration% -o %OutputDirectory%
 popd
 pushd %~dp0src\cli\Microsoft.DotNet.xunit.performance.analysis.cli
 call %DotNet% restore
-call %DotNet% build -c Release
-call %DotNet% pack -c Release -o %OutputDirectory%
+call %DotNet% build -c %BuildConfiguration%
+call %DotNet% pack -c %BuildConfiguration% -o %OutputDirectory%
 popd
 
 goto :eof

--- a/CiBuild.cmd
+++ b/CiBuild.cmd
@@ -13,7 +13,7 @@ call :Usage && exit /b 1
 
 msbuild.exe /nologo /v:m /m /p:Configuration=%BuildConfiguration% /t:CI /fl xunit.performance.msbuild
 
-BuildCliComponents.cmd
+BuildCliComponents.cmd %BuildConfiguration%
 
 goto :eof
 

--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -30,6 +30,6 @@ echo WARNING: Please be careful not to check in those modifications.
 
 msbuild.exe /m /nologo /t:Nightly /v:m /fl xunit.performance.msbuild
 
-BuildCliComponents.cmd
+BuildCliComponents.cmd Release
 
 goto :eof


### PR DESCRIPTION
Prior to this change, BuildCliComponents.cmd always build Release.  Now by default it builds debug, but respects command line input to specify the build configuration.

The build configuration is also specified via NightlyBuild.cmd (which always builds release) and CiBuild.cmd (which builds both debug and release based on input).