### PR TITLE
Stability Improvements for Performance Measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ void EmptyBenchmark()
 }
 ```
 
+For very small benchmarks that complete very quickly (microseconds), it is recommend to add an inner loop to ensure that test code runs long enough to dominate the harness overhead:
+
+1. Add the for loop using iteration.InnerIterationsCount as the number of loop iterations
+2. Specify the value of InnerIterationsCount using the [Benchmark] attribute
+
+```csharp
+[Benchmark(InnerIterationsCount=500)]
+void TestMethod()
+{
+  foreach (var iteration in Benchmark.Iterations)
+    using (iteration.StartMeasurement())
+      for(int i=0; i<iteration.InnerIterationsCount; i++)
+        // test code here
+}
+```
+
 The first iteration is the "warmup" iteration; all performance metrics are discarded by the result analyzer.  Subsequent iterations are measured. 
 
 ## Running benchmarks

--- a/samples/SimplePerfTests/StringThroughput.cs
+++ b/samples/SimplePerfTests/StringThroughput.cs
@@ -36,11 +36,14 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                int strLength = i1.Length;
-
-                for (int j = 0; j < strLength; j++)
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
-                    counter += i1[j];
+                    int strLength = i1.Length;
+
+                    for (int j = 0; j < strLength; j++)
+                    {
+                        counter += i1[j];
+                    }
                 }
             }
         }
@@ -53,9 +56,12 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                for (int j = 0; j < i1.Length; j++)
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
-                    counter += i1[j];
+                    for (int j = 0; j < i1.Length; j++)
+                    {
+                        counter += i1[j];
+                    }
                 }
             }
         }
@@ -68,9 +74,12 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                for (int j = 0; j < i1.Length; j++)
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
-                    counter += GetStringCharNoInline(i1, j);
+                    for (int j = 0; j < i1.Length; j++)
+                    {
+                        counter += GetStringCharNoInline(i1, j);
+                    }
                 }
             }
         }
@@ -103,7 +112,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.ToUpper();
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.ToUpper();
     }
 
     [Benchmark]
@@ -112,7 +122,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.ToUpperInvariant();
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.ToUpperInvariant();
     }
 
     public static IEnumerable<object[]> TrimStrings => MakeArgs(
@@ -149,7 +160,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.Trim();
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.Trim();
     }
 
     [Benchmark]
@@ -158,7 +170,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.Trim(c);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.Trim(c);
     }
 
     [Benchmark]
@@ -167,7 +180,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.TrimStart(c);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.TrimStart(c);
     }
 
     [Benchmark]
@@ -176,7 +190,8 @@ public static class StringThroughput
     {
         foreach (var iteration in Benchmark.Iterations)
             using (iteration.StartMeasurement())
-                s.TrimEnd(c);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    s.TrimEnd(c);
     }
 
     #region more tests
@@ -267,9 +282,12 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                bool b;
-                b = s_e1 == s_e2; b = s_e2 == s_e3; b = s_e3 == s_e4; b = s_e4 == s_e5; b = s_e5 == s_e6; b = s_e6 == s_e7; b = s_e7 == s_e8; b = s_e8 == s_e9; b = s_e9 == s_e1;
-                b = s_e1 == s_e1a; b = s_e2 == s_e2a; b = s_e3 == s_e3a; b = s_e4 == s_e4a; b = s_e5 == s_e5a; b = s_e6 == s_e6a; b = s_e7 == s_e7a; b = s_e8 == s_e8a; b = s_e9 == s_e9a;
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    bool b;
+                    b = s_e1 == s_e2; b = s_e2 == s_e3; b = s_e3 == s_e4; b = s_e4 == s_e5; b = s_e5 == s_e6; b = s_e6 == s_e7; b = s_e7 == s_e8; b = s_e8 == s_e9; b = s_e9 == s_e1;
+                    b = s_e1 == s_e1a; b = s_e2 == s_e2a; b = s_e3 == s_e3a; b = s_e4 == s_e4a; b = s_e5 == s_e5a; b = s_e6 == s_e6a; b = s_e7 == s_e7a; b = s_e8 == s_e8a; b = s_e9 == s_e9a;
+                }
             }
         }
     }
@@ -281,14 +299,17 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_e1.Remove(0); s_e2.Remove(0); s_e2.Remove(1);
-                s_e3.Remove(0); s_e3.Remove(2); s_e3.Remove(3);
-                s_e4.Remove(0); s_e4.Remove(18); s_e4.Remove(22);
-                s_e5.Remove(0); s_e5.Remove(7); s_e5.Remove(10);
-                s_e6.Remove(0); s_e6.Remove(3); s_e6.Remove(4);
-                s_e7.Remove(0); s_e7.Remove(3); s_e7.Remove(4);
-                s_e8.Remove(0); s_e8.Remove(3);
-                s_e9.Remove(0); s_e9.Remove(4);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_e1.Remove(0); s_e2.Remove(0); s_e2.Remove(1);
+                    s_e3.Remove(0); s_e3.Remove(2); s_e3.Remove(3);
+                    s_e4.Remove(0); s_e4.Remove(18); s_e4.Remove(22);
+                    s_e5.Remove(0); s_e5.Remove(7); s_e5.Remove(10);
+                    s_e6.Remove(0); s_e6.Remove(3); s_e6.Remove(4);
+                    s_e7.Remove(0); s_e7.Remove(3); s_e7.Remove(4);
+                    s_e8.Remove(0); s_e8.Remove(3);
+                    s_e9.Remove(0); s_e9.Remove(4);
+                }
             }
         }
     }
@@ -300,14 +321,17 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_e1.Remove(0, 0); s_e2.Remove(0, 1); s_e2.Remove(1, 0);
-                s_e3.Remove(0, 2); s_e3.Remove(2, 1); s_e3.Remove(3, 0);
-                s_e4.Remove(0, 3); s_e4.Remove(18, 3); s_e4.Remove(22, 1);
-                s_e5.Remove(0, 8); s_e5.Remove(7, 4); s_e5.Remove(10, 1);
-                s_e6.Remove(0, 2); s_e6.Remove(3, 1); s_e6.Remove(4, 0);
-                s_e7.Remove(0, 4); s_e7.Remove(3, 2); s_e7.Remove(4, 1);
-                s_e8.Remove(0, 2); s_e8.Remove(3, 3);
-                s_e9.Remove(0, 3); s_e9.Remove(4, 1);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_e1.Remove(0, 0); s_e2.Remove(0, 1); s_e2.Remove(1, 0);
+                    s_e3.Remove(0, 2); s_e3.Remove(2, 1); s_e3.Remove(3, 0);
+                    s_e4.Remove(0, 3); s_e4.Remove(18, 3); s_e4.Remove(22, 1);
+                    s_e5.Remove(0, 8); s_e5.Remove(7, 4); s_e5.Remove(10, 1);
+                    s_e6.Remove(0, 2); s_e6.Remove(3, 1); s_e6.Remove(4, 0);
+                    s_e7.Remove(0, 4); s_e7.Remove(3, 2); s_e7.Remove(4, 1);
+                    s_e8.Remove(0, 2); s_e8.Remove(3, 3);
+                    s_e9.Remove(0, 3); s_e9.Remove(4, 1);
+                }
             }
         }
     }
@@ -317,17 +341,20 @@ public static class StringThroughput
     private static string s_f3 = "More testing: {0}";
     private static string s_f4 = "More testing: {0} {1} {2} {3} {4} {5}{6} {7}";
 
-    [Benchmark]
+    [Benchmark(InnerIterationCount = 600)]
     public static void Format()
     {
         foreach (var iteration in Benchmark.Iterations)
         {
             using (iteration.StartMeasurement())
             {
-                String.Format(s_f1, 8); String.Format(s_f1, 0); String.Format(s_f2, 0); String.Format(s_f2, -2); String.Format(s_f2, 3.14159); String.Format(s_f2, 11000000);
-                String.Format(s_f3, 0); String.Format(s_f3, -2); String.Format(s_f3, 3.14159); String.Format(s_f3, 11000000); String.Format(s_f3, "Foo");
-                String.Format(s_f3, 'a'); String.Format(s_f3, s_f1);
-                String.Format(s_f4, '1', "Foo", "Foo", "Foo", "Foo", "Foo", "Foo", "Foo");
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    String.Format(s_f1, 8); String.Format(s_f1, 0); String.Format(s_f2, 0); String.Format(s_f2, -2); String.Format(s_f2, 3.14159); String.Format(s_f2, 11000000);
+                    String.Format(s_f3, 0); String.Format(s_f3, -2); String.Format(s_f3, 3.14159); String.Format(s_f3, 11000000); String.Format(s_f3, "Foo");
+                    String.Format(s_f3, 'a'); String.Format(s_f3, s_f1);
+                    String.Format(s_f4, '1', "Foo", "Foo", "Foo", "Foo", "Foo", "Foo", "Foo");
+                }
             }
         }
     }
@@ -349,7 +376,10 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_h1.GetHashCode(); s_h2.GetHashCode(); s_h3.GetHashCode(); s_h4.GetHashCode(); s_h5.GetHashCode(); s_h6.GetHashCode(); s_h7.GetHashCode(); s_h8.GetHashCode(); s_h9.GetHashCode();
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_h1.GetHashCode(); s_h2.GetHashCode(); s_h3.GetHashCode(); s_h4.GetHashCode(); s_h5.GetHashCode(); s_h6.GetHashCode(); s_h7.GetHashCode(); s_h8.GetHashCode(); s_h9.GetHashCode();
+                }
             }
         }
     }
@@ -363,11 +393,14 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_p1.PadLeft(0);
-                s_p1.PadLeft(1);
-                s_p1.PadLeft(5);
-                s_p1.PadLeft(18);
-                s_p1.PadLeft(2142);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_p1.PadLeft(0);
+                    s_p1.PadLeft(1);
+                    s_p1.PadLeft(5);
+                    s_p1.PadLeft(18);
+                    s_p1.PadLeft(2142);
+                }
             }
         }
     }
@@ -379,12 +412,15 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                string.Compare("The quick brown fox", "The quick brown fox");
-                string.Compare("The quick brown fox", "The quick brown fox j");
-                string.Compare("Th\u00e9 quick brown f\u00f2x", "Th\u00e9 quick brown f\u00f2x");
-                string.Compare("Th\u00e9 quick brown f\u00f2x", "Th\u00e9 quick brown f\u00f2x jumped");
-                string.Compare("a\u0300a\u0300a\u0300", "\u00e0\u00e0\u00e0");
-                string.Compare("a\u0300a\u0300a\u0300", "\u00c0\u00c0\u00c0");
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    string.Compare("The quick brown fox", "The quick brown fox");
+                    string.Compare("The quick brown fox", "The quick brown fox j");
+                    string.Compare("Th\u00e9 quick brown f\u00f2x", "Th\u00e9 quick brown f\u00f2x");
+                    string.Compare("Th\u00e9 quick brown f\u00f2x", "Th\u00e9 quick brown f\u00f2x jumped");
+                    string.Compare("a\u0300a\u0300a\u0300", "\u00e0\u00e0\u00e0");
+                    string.Compare("a\u0300a\u0300a\u0300", "\u00c0\u00c0\u00c0");
+                }
             }
         }
     }
@@ -396,14 +432,17 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_e1.Substring(0); s_e2.Substring(0); s_e2.Substring(1);
-                s_e3.Substring(0); s_e3.Substring(2); s_e3.Substring(3);
-                s_e4.Substring(0); s_e4.Substring(18); s_e4.Substring(22);
-                s_e5.Substring(0); s_e5.Substring(7); s_e5.Substring(10);
-                s_e6.Substring(0); s_e6.Substring(3); s_e6.Substring(4);
-                s_e7.Substring(0); s_e7.Substring(3); s_e7.Substring(4);
-                s_e8.Substring(0); s_e8.Substring(3);
-                s_e9.Substring(0); s_e9.Substring(4);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_e1.Substring(0); s_e2.Substring(0); s_e2.Substring(1);
+                    s_e3.Substring(0); s_e3.Substring(2); s_e3.Substring(3);
+                    s_e4.Substring(0); s_e4.Substring(18); s_e4.Substring(22);
+                    s_e5.Substring(0); s_e5.Substring(7); s_e5.Substring(10);
+                    s_e6.Substring(0); s_e6.Substring(3); s_e6.Substring(4);
+                    s_e7.Substring(0); s_e7.Substring(3); s_e7.Substring(4);
+                    s_e8.Substring(0); s_e8.Substring(3);
+                    s_e9.Substring(0); s_e9.Substring(4);
+                }
             }
         }
     }
@@ -415,14 +454,17 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                s_e1.Substring(0, 0); s_e2.Substring(0, 1); s_e2.Substring(1, 0);
-                s_e3.Substring(0, 2); s_e3.Substring(2, 1); s_e3.Substring(3, 0);
-                s_e4.Substring(0, 3); s_e4.Substring(18, 3); s_e4.Substring(22, 1);
-                s_e5.Substring(0, 8); s_e5.Substring(7, 4); s_e5.Substring(10, 1);
-                s_e6.Substring(0, 2); s_e6.Substring(3, 1); s_e6.Substring(4, 0);
-                s_e7.Substring(0, 4); s_e7.Substring(3, 2); s_e7.Substring(4, 1);
-                s_e8.Substring(0, 2); s_e8.Substring(3, 3);
-                s_e9.Substring(0, 3); s_e9.Substring(4, 1);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    s_e1.Substring(0, 0); s_e2.Substring(0, 1); s_e2.Substring(1, 0);
+                    s_e3.Substring(0, 2); s_e3.Substring(2, 1); s_e3.Substring(3, 0);
+                    s_e4.Substring(0, 3); s_e4.Substring(18, 3); s_e4.Substring(22, 1);
+                    s_e5.Substring(0, 8); s_e5.Substring(7, 4); s_e5.Substring(10, 1);
+                    s_e6.Substring(0, 2); s_e6.Substring(3, 1); s_e6.Substring(4, 0);
+                    s_e7.Substring(0, 4); s_e7.Substring(3, 2); s_e7.Substring(4, 1);
+                    s_e8.Substring(0, 2); s_e8.Substring(3, 3);
+                    s_e9.Substring(0, 3); s_e9.Substring(4, 1);
+                }
             }
         }
     }
@@ -456,23 +498,26 @@ public static class StringThroughput
         {
             using (iteration.StartMeasurement())
             {
-                t1.Split(c1, StringSplitOptions.None); t2.Split(c1, StringSplitOptions.None); t3.Split(c1, StringSplitOptions.None); t4.Split(c1, StringSplitOptions.None); t5.Split(c1, StringSplitOptions.None); t6.Split(c1, StringSplitOptions.None); t7.Split(c1, StringSplitOptions.None); t8.Split(c1, StringSplitOptions.None); t9.Split(c1, StringSplitOptions.None); tA.Split(c1, StringSplitOptions.None); tB.Split(c1, StringSplitOptions.None); tC.Split(c1, StringSplitOptions.None);
-                t1.Split(c2, StringSplitOptions.None); t2.Split(c2, StringSplitOptions.None); t3.Split(c2, StringSplitOptions.None); t4.Split(c2, StringSplitOptions.None); t5.Split(c2, StringSplitOptions.None); t6.Split(c2, StringSplitOptions.None); t7.Split(c2, StringSplitOptions.None); t8.Split(c2, StringSplitOptions.None); t9.Split(c2, StringSplitOptions.None); tA.Split(c2, StringSplitOptions.None); tB.Split(c2, StringSplitOptions.None); tC.Split(c2, StringSplitOptions.None);
-                t1.Split(c3, StringSplitOptions.None); t2.Split(c3, StringSplitOptions.None); t3.Split(c3, StringSplitOptions.None); t4.Split(c3, StringSplitOptions.None); t5.Split(c3, StringSplitOptions.None); t6.Split(c3, StringSplitOptions.None); t7.Split(c3, StringSplitOptions.None); t8.Split(c3, StringSplitOptions.None); t9.Split(c3, StringSplitOptions.None); tA.Split(c3, StringSplitOptions.None); tB.Split(c3, StringSplitOptions.None); tC.Split(c3, StringSplitOptions.None);
-                t1.Split(c4, StringSplitOptions.None); t2.Split(c4, StringSplitOptions.None); t3.Split(c4, StringSplitOptions.None); t4.Split(c4, StringSplitOptions.None); t5.Split(c4, StringSplitOptions.None); t6.Split(c4, StringSplitOptions.None); t7.Split(c4, StringSplitOptions.None); t8.Split(c4, StringSplitOptions.None); t9.Split(c4, StringSplitOptions.None); tA.Split(c4, StringSplitOptions.None); tB.Split(c4, StringSplitOptions.None); tC.Split(c4, StringSplitOptions.None);
-                t1.Split(c5, StringSplitOptions.None); t2.Split(c5, StringSplitOptions.None); t3.Split(c5, StringSplitOptions.None); t4.Split(c5, StringSplitOptions.None); t5.Split(c5, StringSplitOptions.None); t6.Split(c5, StringSplitOptions.None); t7.Split(c5, StringSplitOptions.None); t8.Split(c5, StringSplitOptions.None); t9.Split(c5, StringSplitOptions.None); tA.Split(c5, StringSplitOptions.None); tB.Split(c5, StringSplitOptions.None); tC.Split(c5, StringSplitOptions.None);
-                t1.Split(c6, StringSplitOptions.None); t2.Split(c6, StringSplitOptions.None); t3.Split(c6, StringSplitOptions.None); t4.Split(c6, StringSplitOptions.None); t5.Split(c6, StringSplitOptions.None); t6.Split(c6, StringSplitOptions.None); t7.Split(c6, StringSplitOptions.None); t8.Split(c6, StringSplitOptions.None); t9.Split(c6, StringSplitOptions.None); tA.Split(c6, StringSplitOptions.None); tB.Split(c6, StringSplitOptions.None); tC.Split(c6, StringSplitOptions.None);
-                t1.Split(c7, StringSplitOptions.None); t2.Split(c7, StringSplitOptions.None); t3.Split(c7, StringSplitOptions.None); t4.Split(c7, StringSplitOptions.None); t5.Split(c7, StringSplitOptions.None); t6.Split(c7, StringSplitOptions.None); t7.Split(c7, StringSplitOptions.None); t8.Split(c7, StringSplitOptions.None); t9.Split(c7, StringSplitOptions.None); tA.Split(c7, StringSplitOptions.None); tB.Split(c7, StringSplitOptions.None); tC.Split(c7, StringSplitOptions.None);
-                t1.Split(c8, StringSplitOptions.None); t2.Split(c8, StringSplitOptions.None); t3.Split(c8, StringSplitOptions.None); t4.Split(c8, StringSplitOptions.None); t5.Split(c8, StringSplitOptions.None); t6.Split(c8, StringSplitOptions.None); t7.Split(c8, StringSplitOptions.None); t8.Split(c8, StringSplitOptions.None); t9.Split(c8, StringSplitOptions.None); tA.Split(c8, StringSplitOptions.None); tB.Split(c8, StringSplitOptions.None); tC.Split(c8, StringSplitOptions.None);
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    t1.Split(c1, StringSplitOptions.None); t2.Split(c1, StringSplitOptions.None); t3.Split(c1, StringSplitOptions.None); t4.Split(c1, StringSplitOptions.None); t5.Split(c1, StringSplitOptions.None); t6.Split(c1, StringSplitOptions.None); t7.Split(c1, StringSplitOptions.None); t8.Split(c1, StringSplitOptions.None); t9.Split(c1, StringSplitOptions.None); tA.Split(c1, StringSplitOptions.None); tB.Split(c1, StringSplitOptions.None); tC.Split(c1, StringSplitOptions.None);
+                    t1.Split(c2, StringSplitOptions.None); t2.Split(c2, StringSplitOptions.None); t3.Split(c2, StringSplitOptions.None); t4.Split(c2, StringSplitOptions.None); t5.Split(c2, StringSplitOptions.None); t6.Split(c2, StringSplitOptions.None); t7.Split(c2, StringSplitOptions.None); t8.Split(c2, StringSplitOptions.None); t9.Split(c2, StringSplitOptions.None); tA.Split(c2, StringSplitOptions.None); tB.Split(c2, StringSplitOptions.None); tC.Split(c2, StringSplitOptions.None);
+                    t1.Split(c3, StringSplitOptions.None); t2.Split(c3, StringSplitOptions.None); t3.Split(c3, StringSplitOptions.None); t4.Split(c3, StringSplitOptions.None); t5.Split(c3, StringSplitOptions.None); t6.Split(c3, StringSplitOptions.None); t7.Split(c3, StringSplitOptions.None); t8.Split(c3, StringSplitOptions.None); t9.Split(c3, StringSplitOptions.None); tA.Split(c3, StringSplitOptions.None); tB.Split(c3, StringSplitOptions.None); tC.Split(c3, StringSplitOptions.None);
+                    t1.Split(c4, StringSplitOptions.None); t2.Split(c4, StringSplitOptions.None); t3.Split(c4, StringSplitOptions.None); t4.Split(c4, StringSplitOptions.None); t5.Split(c4, StringSplitOptions.None); t6.Split(c4, StringSplitOptions.None); t7.Split(c4, StringSplitOptions.None); t8.Split(c4, StringSplitOptions.None); t9.Split(c4, StringSplitOptions.None); tA.Split(c4, StringSplitOptions.None); tB.Split(c4, StringSplitOptions.None); tC.Split(c4, StringSplitOptions.None);
+                    t1.Split(c5, StringSplitOptions.None); t2.Split(c5, StringSplitOptions.None); t3.Split(c5, StringSplitOptions.None); t4.Split(c5, StringSplitOptions.None); t5.Split(c5, StringSplitOptions.None); t6.Split(c5, StringSplitOptions.None); t7.Split(c5, StringSplitOptions.None); t8.Split(c5, StringSplitOptions.None); t9.Split(c5, StringSplitOptions.None); tA.Split(c5, StringSplitOptions.None); tB.Split(c5, StringSplitOptions.None); tC.Split(c5, StringSplitOptions.None);
+                    t1.Split(c6, StringSplitOptions.None); t2.Split(c6, StringSplitOptions.None); t3.Split(c6, StringSplitOptions.None); t4.Split(c6, StringSplitOptions.None); t5.Split(c6, StringSplitOptions.None); t6.Split(c6, StringSplitOptions.None); t7.Split(c6, StringSplitOptions.None); t8.Split(c6, StringSplitOptions.None); t9.Split(c6, StringSplitOptions.None); tA.Split(c6, StringSplitOptions.None); tB.Split(c6, StringSplitOptions.None); tC.Split(c6, StringSplitOptions.None);
+                    t1.Split(c7, StringSplitOptions.None); t2.Split(c7, StringSplitOptions.None); t3.Split(c7, StringSplitOptions.None); t4.Split(c7, StringSplitOptions.None); t5.Split(c7, StringSplitOptions.None); t6.Split(c7, StringSplitOptions.None); t7.Split(c7, StringSplitOptions.None); t8.Split(c7, StringSplitOptions.None); t9.Split(c7, StringSplitOptions.None); tA.Split(c7, StringSplitOptions.None); tB.Split(c7, StringSplitOptions.None); tC.Split(c7, StringSplitOptions.None);
+                    t1.Split(c8, StringSplitOptions.None); t2.Split(c8, StringSplitOptions.None); t3.Split(c8, StringSplitOptions.None); t4.Split(c8, StringSplitOptions.None); t5.Split(c8, StringSplitOptions.None); t6.Split(c8, StringSplitOptions.None); t7.Split(c8, StringSplitOptions.None); t8.Split(c8, StringSplitOptions.None); t9.Split(c8, StringSplitOptions.None); tA.Split(c8, StringSplitOptions.None); tB.Split(c8, StringSplitOptions.None); tC.Split(c8, StringSplitOptions.None);
 
-                t1.Split(c1, StringSplitOptions.RemoveEmptyEntries); t2.Split(c1, StringSplitOptions.RemoveEmptyEntries); t3.Split(c1, StringSplitOptions.RemoveEmptyEntries); t4.Split(c1, StringSplitOptions.RemoveEmptyEntries); t5.Split(c1, StringSplitOptions.RemoveEmptyEntries); t6.Split(c1, StringSplitOptions.RemoveEmptyEntries); t7.Split(c1, StringSplitOptions.RemoveEmptyEntries); t8.Split(c1, StringSplitOptions.RemoveEmptyEntries); t9.Split(c1, StringSplitOptions.RemoveEmptyEntries); tA.Split(c1, StringSplitOptions.RemoveEmptyEntries); tB.Split(c1, StringSplitOptions.RemoveEmptyEntries); tC.Split(c1, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c2, StringSplitOptions.RemoveEmptyEntries); t2.Split(c2, StringSplitOptions.RemoveEmptyEntries); t3.Split(c2, StringSplitOptions.RemoveEmptyEntries); t4.Split(c2, StringSplitOptions.RemoveEmptyEntries); t5.Split(c2, StringSplitOptions.RemoveEmptyEntries); t6.Split(c2, StringSplitOptions.RemoveEmptyEntries); t7.Split(c2, StringSplitOptions.RemoveEmptyEntries); t8.Split(c2, StringSplitOptions.RemoveEmptyEntries); t9.Split(c2, StringSplitOptions.RemoveEmptyEntries); tA.Split(c2, StringSplitOptions.RemoveEmptyEntries); tB.Split(c2, StringSplitOptions.RemoveEmptyEntries); tC.Split(c2, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c3, StringSplitOptions.RemoveEmptyEntries); t2.Split(c3, StringSplitOptions.RemoveEmptyEntries); t3.Split(c3, StringSplitOptions.RemoveEmptyEntries); t4.Split(c3, StringSplitOptions.RemoveEmptyEntries); t5.Split(c3, StringSplitOptions.RemoveEmptyEntries); t6.Split(c3, StringSplitOptions.RemoveEmptyEntries); t7.Split(c3, StringSplitOptions.RemoveEmptyEntries); t8.Split(c3, StringSplitOptions.RemoveEmptyEntries); t9.Split(c3, StringSplitOptions.RemoveEmptyEntries); tA.Split(c3, StringSplitOptions.RemoveEmptyEntries); tB.Split(c3, StringSplitOptions.RemoveEmptyEntries); tC.Split(c3, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c4, StringSplitOptions.RemoveEmptyEntries); t2.Split(c4, StringSplitOptions.RemoveEmptyEntries); t3.Split(c4, StringSplitOptions.RemoveEmptyEntries); t4.Split(c4, StringSplitOptions.RemoveEmptyEntries); t5.Split(c4, StringSplitOptions.RemoveEmptyEntries); t6.Split(c4, StringSplitOptions.RemoveEmptyEntries); t7.Split(c4, StringSplitOptions.RemoveEmptyEntries); t8.Split(c4, StringSplitOptions.RemoveEmptyEntries); t9.Split(c4, StringSplitOptions.RemoveEmptyEntries); tA.Split(c4, StringSplitOptions.RemoveEmptyEntries); tB.Split(c4, StringSplitOptions.RemoveEmptyEntries); tC.Split(c4, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c5, StringSplitOptions.RemoveEmptyEntries); t2.Split(c5, StringSplitOptions.RemoveEmptyEntries); t3.Split(c5, StringSplitOptions.RemoveEmptyEntries); t4.Split(c5, StringSplitOptions.RemoveEmptyEntries); t5.Split(c5, StringSplitOptions.RemoveEmptyEntries); t6.Split(c5, StringSplitOptions.RemoveEmptyEntries); t7.Split(c5, StringSplitOptions.RemoveEmptyEntries); t8.Split(c5, StringSplitOptions.RemoveEmptyEntries); t9.Split(c5, StringSplitOptions.RemoveEmptyEntries); tA.Split(c5, StringSplitOptions.RemoveEmptyEntries); tB.Split(c5, StringSplitOptions.RemoveEmptyEntries); tC.Split(c5, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c6, StringSplitOptions.RemoveEmptyEntries); t2.Split(c6, StringSplitOptions.RemoveEmptyEntries); t3.Split(c6, StringSplitOptions.RemoveEmptyEntries); t4.Split(c6, StringSplitOptions.RemoveEmptyEntries); t5.Split(c6, StringSplitOptions.RemoveEmptyEntries); t6.Split(c6, StringSplitOptions.RemoveEmptyEntries); t7.Split(c6, StringSplitOptions.RemoveEmptyEntries); t8.Split(c6, StringSplitOptions.RemoveEmptyEntries); t9.Split(c6, StringSplitOptions.RemoveEmptyEntries); tA.Split(c6, StringSplitOptions.RemoveEmptyEntries); tB.Split(c6, StringSplitOptions.RemoveEmptyEntries); tC.Split(c6, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c7, StringSplitOptions.RemoveEmptyEntries); t2.Split(c7, StringSplitOptions.RemoveEmptyEntries); t3.Split(c7, StringSplitOptions.RemoveEmptyEntries); t4.Split(c7, StringSplitOptions.RemoveEmptyEntries); t5.Split(c7, StringSplitOptions.RemoveEmptyEntries); t6.Split(c7, StringSplitOptions.RemoveEmptyEntries); t7.Split(c7, StringSplitOptions.RemoveEmptyEntries); t8.Split(c7, StringSplitOptions.RemoveEmptyEntries); t9.Split(c7, StringSplitOptions.RemoveEmptyEntries); tA.Split(c7, StringSplitOptions.RemoveEmptyEntries); tB.Split(c7, StringSplitOptions.RemoveEmptyEntries); tC.Split(c7, StringSplitOptions.RemoveEmptyEntries);
-                t1.Split(c8, StringSplitOptions.RemoveEmptyEntries); t2.Split(c8, StringSplitOptions.RemoveEmptyEntries); t3.Split(c8, StringSplitOptions.RemoveEmptyEntries); t4.Split(c8, StringSplitOptions.RemoveEmptyEntries); t5.Split(c8, StringSplitOptions.RemoveEmptyEntries); t6.Split(c8, StringSplitOptions.RemoveEmptyEntries); t7.Split(c8, StringSplitOptions.RemoveEmptyEntries); t8.Split(c8, StringSplitOptions.RemoveEmptyEntries); t9.Split(c8, StringSplitOptions.RemoveEmptyEntries); tA.Split(c8, StringSplitOptions.RemoveEmptyEntries); tB.Split(c8, StringSplitOptions.RemoveEmptyEntries); tC.Split(c8, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c1, StringSplitOptions.RemoveEmptyEntries); t2.Split(c1, StringSplitOptions.RemoveEmptyEntries); t3.Split(c1, StringSplitOptions.RemoveEmptyEntries); t4.Split(c1, StringSplitOptions.RemoveEmptyEntries); t5.Split(c1, StringSplitOptions.RemoveEmptyEntries); t6.Split(c1, StringSplitOptions.RemoveEmptyEntries); t7.Split(c1, StringSplitOptions.RemoveEmptyEntries); t8.Split(c1, StringSplitOptions.RemoveEmptyEntries); t9.Split(c1, StringSplitOptions.RemoveEmptyEntries); tA.Split(c1, StringSplitOptions.RemoveEmptyEntries); tB.Split(c1, StringSplitOptions.RemoveEmptyEntries); tC.Split(c1, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c2, StringSplitOptions.RemoveEmptyEntries); t2.Split(c2, StringSplitOptions.RemoveEmptyEntries); t3.Split(c2, StringSplitOptions.RemoveEmptyEntries); t4.Split(c2, StringSplitOptions.RemoveEmptyEntries); t5.Split(c2, StringSplitOptions.RemoveEmptyEntries); t6.Split(c2, StringSplitOptions.RemoveEmptyEntries); t7.Split(c2, StringSplitOptions.RemoveEmptyEntries); t8.Split(c2, StringSplitOptions.RemoveEmptyEntries); t9.Split(c2, StringSplitOptions.RemoveEmptyEntries); tA.Split(c2, StringSplitOptions.RemoveEmptyEntries); tB.Split(c2, StringSplitOptions.RemoveEmptyEntries); tC.Split(c2, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c3, StringSplitOptions.RemoveEmptyEntries); t2.Split(c3, StringSplitOptions.RemoveEmptyEntries); t3.Split(c3, StringSplitOptions.RemoveEmptyEntries); t4.Split(c3, StringSplitOptions.RemoveEmptyEntries); t5.Split(c3, StringSplitOptions.RemoveEmptyEntries); t6.Split(c3, StringSplitOptions.RemoveEmptyEntries); t7.Split(c3, StringSplitOptions.RemoveEmptyEntries); t8.Split(c3, StringSplitOptions.RemoveEmptyEntries); t9.Split(c3, StringSplitOptions.RemoveEmptyEntries); tA.Split(c3, StringSplitOptions.RemoveEmptyEntries); tB.Split(c3, StringSplitOptions.RemoveEmptyEntries); tC.Split(c3, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c4, StringSplitOptions.RemoveEmptyEntries); t2.Split(c4, StringSplitOptions.RemoveEmptyEntries); t3.Split(c4, StringSplitOptions.RemoveEmptyEntries); t4.Split(c4, StringSplitOptions.RemoveEmptyEntries); t5.Split(c4, StringSplitOptions.RemoveEmptyEntries); t6.Split(c4, StringSplitOptions.RemoveEmptyEntries); t7.Split(c4, StringSplitOptions.RemoveEmptyEntries); t8.Split(c4, StringSplitOptions.RemoveEmptyEntries); t9.Split(c4, StringSplitOptions.RemoveEmptyEntries); tA.Split(c4, StringSplitOptions.RemoveEmptyEntries); tB.Split(c4, StringSplitOptions.RemoveEmptyEntries); tC.Split(c4, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c5, StringSplitOptions.RemoveEmptyEntries); t2.Split(c5, StringSplitOptions.RemoveEmptyEntries); t3.Split(c5, StringSplitOptions.RemoveEmptyEntries); t4.Split(c5, StringSplitOptions.RemoveEmptyEntries); t5.Split(c5, StringSplitOptions.RemoveEmptyEntries); t6.Split(c5, StringSplitOptions.RemoveEmptyEntries); t7.Split(c5, StringSplitOptions.RemoveEmptyEntries); t8.Split(c5, StringSplitOptions.RemoveEmptyEntries); t9.Split(c5, StringSplitOptions.RemoveEmptyEntries); tA.Split(c5, StringSplitOptions.RemoveEmptyEntries); tB.Split(c5, StringSplitOptions.RemoveEmptyEntries); tC.Split(c5, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c6, StringSplitOptions.RemoveEmptyEntries); t2.Split(c6, StringSplitOptions.RemoveEmptyEntries); t3.Split(c6, StringSplitOptions.RemoveEmptyEntries); t4.Split(c6, StringSplitOptions.RemoveEmptyEntries); t5.Split(c6, StringSplitOptions.RemoveEmptyEntries); t6.Split(c6, StringSplitOptions.RemoveEmptyEntries); t7.Split(c6, StringSplitOptions.RemoveEmptyEntries); t8.Split(c6, StringSplitOptions.RemoveEmptyEntries); t9.Split(c6, StringSplitOptions.RemoveEmptyEntries); tA.Split(c6, StringSplitOptions.RemoveEmptyEntries); tB.Split(c6, StringSplitOptions.RemoveEmptyEntries); tC.Split(c6, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c7, StringSplitOptions.RemoveEmptyEntries); t2.Split(c7, StringSplitOptions.RemoveEmptyEntries); t3.Split(c7, StringSplitOptions.RemoveEmptyEntries); t4.Split(c7, StringSplitOptions.RemoveEmptyEntries); t5.Split(c7, StringSplitOptions.RemoveEmptyEntries); t6.Split(c7, StringSplitOptions.RemoveEmptyEntries); t7.Split(c7, StringSplitOptions.RemoveEmptyEntries); t8.Split(c7, StringSplitOptions.RemoveEmptyEntries); t9.Split(c7, StringSplitOptions.RemoveEmptyEntries); tA.Split(c7, StringSplitOptions.RemoveEmptyEntries); tB.Split(c7, StringSplitOptions.RemoveEmptyEntries); tC.Split(c7, StringSplitOptions.RemoveEmptyEntries);
+                    t1.Split(c8, StringSplitOptions.RemoveEmptyEntries); t2.Split(c8, StringSplitOptions.RemoveEmptyEntries); t3.Split(c8, StringSplitOptions.RemoveEmptyEntries); t4.Split(c8, StringSplitOptions.RemoveEmptyEntries); t5.Split(c8, StringSplitOptions.RemoveEmptyEntries); t6.Split(c8, StringSplitOptions.RemoveEmptyEntries); t7.Split(c8, StringSplitOptions.RemoveEmptyEntries); t8.Split(c8, StringSplitOptions.RemoveEmptyEntries); t9.Split(c8, StringSplitOptions.RemoveEmptyEntries); tA.Split(c8, StringSplitOptions.RemoveEmptyEntries); tB.Split(c8, StringSplitOptions.RemoveEmptyEntries); tC.Split(c8, StringSplitOptions.RemoveEmptyEntries);
+                }
             }
         }
     }

--- a/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
@@ -15,7 +15,8 @@
     "define": [ "LINUX_BUILD" ]
   },
   "compileFiles": [
-    "../../xunit.performance.analysis/Program.cs"
+    "../../xunit.performance.analysis/Program.cs",
+    "../../xunit.performance.analysis/TestStatistics.cs"
   ],
   "dependencies": {
       "Microsoft.NETCore.DotNetHostPolicy":"1.0.1-rc2-002357-00",

--- a/src/xunit.performance.analysis/Program.cs
+++ b/src/xunit.performance.analysis/Program.cs
@@ -163,12 +163,14 @@ namespace Microsoft.Xunit.Performance.Analysis
                     var stdErrorDiff = Math.Sqrt((baselineSumOfSquares - (baselineSumSquared / baselineCount) + comparisonSumOfSquares - (comparisonSumSquared / comparisonCount)) * (1.0 / baselineCount + 1.0 / comparisonCount) / (baselineCount + comparisonCount - 1));
                     var interval = stdErrorDiff * MathNet.Numerics.ExcelFunctions.TInv(1.0 - ErrorConfidence, baselineCount + comparisonCount - 2);
 
+                    RunningStatistics comparisonStats = comparisonTest.Stats[DurationMetricName].RunningStatistics;
+                    RunningStatistics baselineStats = baselineTest.Stats[DurationMetricName].RunningStatistics;
                     var comparisonResult = new TestResultComparison();
                     comparisonResult.BaselineResult = baselineTest;
                     comparisonResult.ComparisonResult = comparisonTest;
                     comparisonResult.TestName = comparisonTest.TestName;
-                    comparisonResult.PercentChange = (comparisonTest.Stats[DurationMetricName].Mean - baselineTest.Stats[DurationMetricName].Mean) / baselineTest.Stats[DurationMetricName].Mean;
-                    comparisonResult.PercentChangeError = interval / baselineTest.Stats[DurationMetricName].Mean;
+                    comparisonResult.PercentChange = (comparisonStats.Mean - baselineStats.Mean) / baselineStats.Mean;
+                    comparisonResult.PercentChangeError = interval / baselineStats.Mean;
 
                     comparisonResults.Add(comparisonResult);
                 }
@@ -197,12 +199,13 @@ namespace Microsoft.Xunit.Performance.Analysis
 
                     foreach (var stat in result.Stats)
                     {
+                        RunningStatistics runningStats = stat.Value.RunningStatistics;
                         summaryElem.Add(new XElement(stat.Key,
-                            new XAttribute("min", stat.Value.Minimum.ToString("G3")),
-                            new XAttribute("mean", stat.Value.Mean.ToString("G3")),
-                            new XAttribute("max", stat.Value.Maximum.ToString("G3")),
-                            new XAttribute("marginOfError", stat.Value.MarginOfError(ErrorConfidence).ToString("G3")),
-                            new XAttribute("stddev", stat.Value.StandardDeviation.ToString("G3"))));
+                            new XAttribute("min", runningStats.Minimum.ToString("G3")),
+                            new XAttribute("mean", runningStats.Mean.ToString("G3")),
+                            new XAttribute("max", runningStats.Maximum.ToString("G3")),
+                            new XAttribute("marginOfError", runningStats.MarginOfError(ErrorConfidence).ToString("G3")),
+                            new XAttribute("stddev", runningStats.StandardDeviation.ToString("G3"))));
                     }
                 }
             }
@@ -253,11 +256,11 @@ namespace Microsoft.Xunit.Performance.Analysis
                     writer.WriteLine($"<h1>Indivdual results: {run.Key}</h1>");
 
                     writer.WriteLine($"<table>");
-                    writer.WriteLine($"<tr><th>Test</th><th>Unit</th><th>Min</th><th>Mean</th><th>Max</th><th>Margin</th><th>StdDev</th></tr>");
+                    writer.WriteLine($"<tr><th>Test</th><th>Unit</th><th>Min</th><th>Mean</th><th>Max</th><th>Margin</th><th>StdDev</th><th>Iterations</th></tr>");
                     foreach (var test in run.Value)
                     {
-                        var stats = test.Value.Stats[DurationMetricName];
-                        writer.WriteLine($"<tr><td>{test.Value.TestName}</td><td>ms</td><td>{stats.Minimum.ToString("G3")}</td><td>{stats.Mean.ToString("G3")}</td><td>{stats.Maximum.ToString("G3")}</td><td>{stats.MarginOfError(ErrorConfidence).ToString("P1")}</td><td>{stats.StandardDeviation.ToString("G3")}</td></tr>");
+                        var stats = test.Value.Stats[DurationMetricName].RunningStatistics;
+                        writer.WriteLine($"<tr><td>{test.Value.TestName}</td><td>ms</td><td>{stats.Minimum.ToString("G3")}</td><td>{stats.Mean.ToString("G3")}</td><td>{stats.Maximum.ToString("G3")}</td><td>{stats.MarginOfError(ErrorConfidence).ToString("P1")}</td><td>{stats.StandardDeviation.ToString("G3")}</td><td>{test.Value.Stats[DurationMetricName].IterationCount.ToString()}</td></tr>");
                     }
                     writer.WriteLine($"</table>");
                 }
@@ -315,9 +318,9 @@ namespace Microsoft.Xunit.Performance.Analysis
 
                 foreach (var metric in iteration.MetricValues)
                 {
-                    RunningStatistics stats;
+                    TestStatistics stats;
                     if (!result.Stats.TryGetValue(metric.Key, out stats))
-                        result.Stats[metric.Key] = stats = new RunningStatistics();
+                        result.Stats[metric.Key] = stats = new TestStatistics();
                     stats.Push(metric.Value);
                 }
 
@@ -390,24 +393,11 @@ namespace Microsoft.Xunit.Performance.Analysis
             }
         }
 
-#if LINUX_BUILD
-        public class RunningStatistics
-        {
-            public RunningStatistics() {
-                values = new List<Double>();
-            }
-            public List<Double> values;
-            public void Push(Double value)
-            {
-                values.Add(value);
-            }
-        }
-#endif
         private class TestResult
         {
             public string TestName;
             public string RunId;
-            public Dictionary<string, RunningStatistics> Stats = new Dictionary<string, RunningStatistics>();
+            public Dictionary<string, TestStatistics> Stats = new Dictionary<string, TestStatistics>();
             public List<TestIterationResult> Iterations = new List<TestIterationResult>();
         }
 

--- a/src/xunit.performance.analysis/Program.cs
+++ b/src/xunit.performance.analysis/Program.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Xunit.Performance.Analysis
                 {
                     foreach (var result in run.Value.Values)
                     {
-                        RunningStatistics durationStats = result.Stats[DurationMetricName];
+                        RunningStatistics durationStats = result.Stats[DurationMetricName].RunningStatistics;
                         writer.WriteLine(
                             "\"{0}\",\"{1}\",\"{2}\",\"{3}\",\"{4}\",\"{5}\",\"{6}\"",
                             EscapeCsvString(result.TestName),
@@ -367,7 +367,7 @@ namespace Microsoft.Xunit.Performance.Analysis
         }
 
 
-        private static string GetMetricsString(Dictionary<string, RunningStatistics>.KeyCollection metrics)
+        private static string GetMetricsString(Dictionary<string, TestStatistics>.KeyCollection metrics)
         {
             StringBuilder builder = new StringBuilder();
             foreach (string metric in metrics)

--- a/src/xunit.performance.analysis/TestStatistics.cs
+++ b/src/xunit.performance.analysis/TestStatistics.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+#if !LINUX_BUILD
+using MathNet.Numerics.Statistics;
+#endif
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    public class TestStatistics
+    {
+        private bool _readOnly;
+        private List<double> _values;
+        private RunningStatistics _cachedStatistics;
+
+        public TestStatistics()
+        {
+            _values = new List<double>();
+        }
+
+        public void Push(double value)
+        {
+            if (_readOnly)
+                throw new InvalidOperationException("Statistics have already been calculated.  Data is now read-only.");
+            _values.Add(value);
+        }
+
+        public RunningStatistics RunningStatistics
+        {
+            get
+            {
+                if(_cachedStatistics == null)
+                {
+                    _readOnly = true;
+                    TransformData();
+                    _cachedStatistics = new RunningStatistics(_values);
+                }
+
+                return _cachedStatistics;
+            }
+        }
+
+        public int IterationCount
+        {
+            get { return _values.Count; }
+        }
+
+        private void TransformData()
+        {
+            double[] values = _values.ToArray();
+
+            // Sort the values.
+            Array.Sort(values);
+
+            // Get the 1st and 99th percentile values.
+            double firstPercentileVal = PercentileInSortedArray(values, 1);
+            double ninetyninthPercentileVal = PercentileInSortedArray(values, 99);
+
+            int startIndex = 0;
+            int stopIndex = values.Length - 1;
+            
+            // Find the new start-index.
+            for(int i=0; i<values.Length; i++)
+            {
+                if(values[i] > firstPercentileVal)
+                {
+                    startIndex = i;
+                    break;
+                }
+            }
+
+            // Find the new end-index.
+            for(int i=values.Length-1; i>=0; i--)
+            {
+                if(values[i] < ninetyninthPercentileVal)
+                {
+                    stopIndex = i;
+                    break;
+                }
+            }
+
+            // Subset the array.
+            // Add 1 because we want to include stopIndex in the new data set.
+            int newArrayLength = stopIndex - startIndex + 1;
+            double[] newValues = new double[newArrayLength];
+            int newArrayIndex = 0;
+            for(int i=startIndex; i<=stopIndex; i++)
+            {
+                newValues[newArrayIndex++] = values[i];
+            }
+
+            // Swap in the updated set of values.
+            _values = new List<double>(newValues);
+        }
+
+        private static double PercentileInSortedArray(double[] values, int percentage)
+        {
+            if(values == null || values.Length <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(values));
+            }
+
+            if(percentage < 0 || percentage > 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(percentage));
+            }
+
+            // Calculate the array slot where the nth percentile lives.
+            int n = (percentage / 100) * (values.Length-1);
+
+            return values[n];
+        }
+    }
+
+#if LINUX_BUILD
+    // MathNet nuget package can't be used on Linux,
+    // but we don't need most of its functionality anyway.
+    public class RunningStatistics
+    {
+        public RunningStatistics()
+        {
+            values = new List<Double>();
+        }
+
+        public RunningStatistics(IEnumerable<double> values)
+        {
+            values = new List<double>(values);
+        }
+
+        public List<Double> values;
+        public void Push(Double value)
+        {
+            values.Add(value);
+        }
+    }
+#endif
+}

--- a/src/xunit.performance.analysis/TestStatistics.cs
+++ b/src/xunit.performance.analysis/TestStatistics.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Xunit.Performance.Analysis
             int stopIndex = values.Length - 1;
             
             // Find the new start-index.
-            for(int i=0; i<values.Length; i++)
+            for(int i = 0; i < values.Length; i++)
             {
                 if(values[i] > firstPercentileVal)
                 {
@@ -69,7 +69,7 @@ namespace Microsoft.Xunit.Performance.Analysis
             }
 
             // Find the new end-index.
-            for(int i=values.Length-1; i>=0; i--)
+            for(int i = values.Length-1; i >= 0; i--)
             {
                 if(values[i] < ninetyninthPercentileVal)
                 {
@@ -82,11 +82,7 @@ namespace Microsoft.Xunit.Performance.Analysis
             // Add 1 because we want to include stopIndex in the new data set.
             int newArrayLength = stopIndex - startIndex + 1;
             double[] newValues = new double[newArrayLength];
-            int newArrayIndex = 0;
-            for(int i=startIndex; i<=stopIndex; i++)
-            {
-                newValues[newArrayIndex++] = values[i];
-            }
+            Array.Copy(values, startIndex, newValues, 0, newArrayLength);
 
             // Swap in the updated set of values.
             _values = new List<double>(newValues);
@@ -105,7 +101,7 @@ namespace Microsoft.Xunit.Performance.Analysis
             }
 
             // Calculate the array slot where the nth percentile lives.
-            int n = (percentage / 100) * (values.Length-1);
+            int n = (int)(((double)percentage / 100) * (values.Length-1));
 
             return values[n];
         }

--- a/src/xunit.performance.analysis/xunit.performance.analysis.csproj
+++ b/src/xunit.performance.analysis/xunit.performance.analysis.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Microsoft-Xunit-Benchmark.manifest.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestStatistics.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/xunit.performance.core/Benchmark.cs
+++ b/src/xunit.performance.core/Benchmark.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Xunit.Performance
         public static IEnumerable<BenchmarkIteration> Iterations => BenchmarkIterator.Current.Iterations;
 
         /// <summary>
+        /// Gets the inner iteration count (the count of actual iterations that should occur for each benchmark iteration).
+        /// </summary>
+        public static long InnerIterationCount => BenchmarkIterator.Current.InnerIterationCount;
+
+        /// <summary>
         /// Automatically iterate over a measured operation.
         /// </summary>
         /// <param name="measuredOperation">The operation to measure and iterate over.</param>
@@ -33,7 +38,10 @@ namespace Microsoft.Xunit.Performance
             {
                 using (var measurement = iteration.StartMeasurement())
                 {
-                    measuredOperation.Invoke();
+                    for (int i = 0; i < BenchmarkIterator.Current.InnerIterationCount; i++)
+                    {
+                        measuredOperation.Invoke();
+                    }
                 }
             }
         }
@@ -48,7 +56,10 @@ namespace Microsoft.Xunit.Performance
             {
                 using (var measurement = iteration.StartMeasurement())
                 {
-                    await asyncMeasuredOperation.Invoke();
+                    for (int i = 0; i < BenchmarkIterator.Current.InnerIterationCount; i++)
+                    {
+                        await asyncMeasuredOperation.Invoke();
+                    }
                 }
             }
         }

--- a/src/xunit.performance.core/BenchmarkAttribute.cs
+++ b/src/xunit.performance.core/BenchmarkAttribute.cs
@@ -18,5 +18,15 @@ namespace Microsoft.Xunit.Performance
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class BenchmarkAttribute : FactAttribute, IPerformanceMetricAttribute, ITraitAttribute
     {
+        private long _innerIterationsCount = 1;
+
+        /// <summary>
+        /// Get or set the count of inner iterations to run inside of each harness iteration.
+        /// </summary>
+        public long InnerIterationCount
+        {
+            get { return _innerIterationsCount; }
+            set { _innerIterationsCount = value; }
+        }
     }
 }

--- a/src/xunit.performance.core/BenchmarkIterator.cs
+++ b/src/xunit.performance.core/BenchmarkIterator.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Xunit.Performance.Internal
         protected internal abstract IEnumerable<BenchmarkIteration> Iterations { get; }
 
         /// <summary>
+        /// Gets the inner iteration count for the current benchmark
+        /// </summary>
+        protected internal abstract long InnerIterationCount { get; }
+
+        /// <summary>
         /// Starts measurement for the given iteration, if it is the current iteration.
         /// </summary>
         /// <param name="iterationNumber"></param>

--- a/src/xunit.performance.execution/BenchmarkConfiguration.cs
+++ b/src/xunit.performance.execution/BenchmarkConfiguration.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Xunit.Performance
         public static readonly string RunId = Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_RUN_ID");
         public static readonly int MinIteration = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MIN_ITERATION") ?? "1");
         public static readonly int MaxIteration = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_ITERATION") ?? "0");
+        public static readonly int MaxIterationWhenInnerSpecified = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED") ?? "0");
         public static readonly int MaxTotalMilliseconds = int.Parse(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS") ?? "0");
         public static readonly string FileLogPath = Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_FILE_LOG_PATH");
         public static bool RunningAsPerfTest => RunId != null;

--- a/src/xunit.performance.execution/BenchmarkEventSource.cs
+++ b/src/xunit.performance.execution/BenchmarkEventSource.cs
@@ -145,32 +145,29 @@ namespace Microsoft.Xunit.Performance
         }
 
         [Event(4, Opcode = EventOpcode.Info, Task = Tasks.BenchmarkIterationStop)]
-        public unsafe void BenchmarkIterationStop(string RunId, string BenchmarkName, int Iteration, bool Success)
+        public unsafe void BenchmarkIterationStop(string RunId, string BenchmarkName, int Iteration)
         {
             if (IsEnabled())
             {
                 if (RunId == null)
                     RunId = "";
 
-                int successInt = Success ? 1 : 0;
                 fixed (char* pRunId = RunId)
                 fixed (char* pBenchmarkName = BenchmarkName)
                 {
-                    EventData* data = stackalloc EventData[4];
+                    EventData* data = stackalloc EventData[3];
                     data[0].Size = (RunId.Length + 1) * sizeof(char);
                     data[0].DataPointer = (IntPtr)pRunId;
                     data[1].Size = (BenchmarkName.Length + 1) * 2;
                     data[1].DataPointer = (IntPtr)pBenchmarkName;
                     data[2].Size = sizeof(int);
                     data[2].DataPointer = (IntPtr)(&Iteration);
-                    data[3].Size = sizeof(int);
-                    data[3].DataPointer = (IntPtr)(&successInt);
-                    WriteEventCore(4, 4, data);
+                    WriteEventCore(4, 3, data);
                 }
             }
 
             if (_csvWriter != null)
-                WriteCSV(BenchmarkName, iteration: Iteration, success: Success);
+                WriteCSV(BenchmarkName, iteration: Iteration);
         }
     }
 }

--- a/src/xunit.performance.run/Microsoft-Xunit-Benchmark.manifest.cs
+++ b/src/xunit.performance.run/Microsoft-Xunit-Benchmark.manifest.cs
@@ -206,7 +206,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
         public string RunId { get { return GetUnicodeStringAt(0); } }
         public string BenchmarkName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
         public int Iteration { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(0))); } }
-        public bool Success { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(0)) + 4) != 0; } }
 
         #region Private
         internal BenchmarkIterationStopArgs(Action<BenchmarkIterationStopArgs> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -234,7 +233,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
             XmlAttrib(sb, "RunId", RunId);
             XmlAttrib(sb, "BenchmarkName", BenchmarkName);
             XmlAttrib(sb, "Iteration", Iteration);
-            XmlAttrib(sb, "Success", Success);
             sb.Append("/>");
             return sb;
         }
@@ -244,7 +242,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "RunId", "BenchmarkName", "Iteration", "Success" };
+                    payloadNames = new string[] { "RunId", "BenchmarkName", "Iteration" };
                 return payloadNames;
             }
         }
@@ -259,8 +257,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
                     return BenchmarkName;
                 case 2:
                     return Iteration;
-                case 3:
-                    return Success;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;

--- a/src/xunit.performance.run/ProgramCore.cs
+++ b/src/xunit.performance.run/ProgramCore.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Xunit.Performance
 {
     public abstract class ProgramCore
     {
+        private const int MinIterations = 1;
+        private const int MaxIterations = 1000;
+        private const int MaxIterationsWhenInnerIterationsSpecified = 100;
+        private const int MaxTotalMSPerTest = 10000;    // 10 seconds
 
         private bool _nologo = false;
         private bool _verbose = false;
@@ -137,11 +141,25 @@ namespace Microsoft.Xunit.Performance
             };
 
             startInfo.Environment["XUNIT_PERFORMANCE_RUN_ID"] = project.RunId;
-            startInfo.Environment["XUNIT_PERFORMANCE_MIN_ITERATION"] = "10";
-            startInfo.Environment["XUNIT_PERFORMANCE_MAX_ITERATION"] = "1000";
-            startInfo.Environment["XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS"] = "1000";
-            startInfo.Environment["COMPLUS_gcConcurrent"] = "0";
-            startInfo.Environment["COMPLUS_gcServer"] = "0";
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MIN_ITERATION")))
+                startInfo.Environment["XUNIT_PERFORMANCE_MIN_ITERATION"] = MinIterations.ToString();
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_ITERATION")))
+                startInfo.Environment["XUNIT_PERFORMANCE_MAX_ITERATION"] = MaxIterations.ToString();
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED")))
+                startInfo.Environment["XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED"] = MaxIterationsWhenInnerIterationsSpecified.ToString();
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS")))
+                startInfo.Environment["XUNIT_PERFORMANCE_MAX_TOTAL_MILLISECONDS"] = MaxTotalMSPerTest.ToString();
+
+            // Disable server and background GC.
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_gcConcurrent")))
+                startInfo.Environment["COMPLUS_gcConcurrent"] = "0";
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("COMPLUS_gcServer")))
+                startInfo.Environment["COMPLUS_gcServer"] = "0";
 
             var logger = GetPerformanceMetricLogger(project);
             using (logger.StartLogging(startInfo))


### PR DESCRIPTION
This change includes two stability improvements:

1. Throw out the 1st and 99th percentile results during analysis.
2. Allow for "inner iterations" to be specified.  This is to be used when a microbechmark runs too quickly and thus doesn't get measured in a stable way by the harness.  Generally, I've found that tests in the millisecond range are generating much more stable data (+ or - 1 to 3%), where as without this change, they are measuring + or - as much as 50%.

Number 2 above requires changes to test code in the form of adding an inner loop and specifying the count via [Benchmark(InnerIterationsCount=500)].  This is optional and need only be used when benchmarks execute too quickly to be accurately measured via the execution timer.