### PR TITLE
Apply existing comparison analysis to all observed metrics. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ ModelManifest.xml
 nuget.exe
 *.nuget.props
 *.nuget.targets
+*.etl

--- a/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli/project.json
@@ -15,8 +15,18 @@
     "define": [ "LINUX_BUILD" ]
   },
   "compileFiles": [
+    "../../xunit.performance.analysis/MathExtensions.cs",
     "../../xunit.performance.analysis/Program.cs",
-    "../../xunit.performance.analysis/TestStatistics.cs"
+    "../../xunit.performance.analysis/Properties.cs",
+    "../../xunit.performance.analysis/TestIterationResult.cs",
+    "../../xunit.performance.analysis/TestResult.cs",
+    "../../xunit.performance.analysis/TestResultComparison.cs",
+    "../../xunit.performance.analysis/TestStatistics.cs",
+    "../../xunit.performance.analysis/Writers/AbstractResultsWriter.cs",
+    "../../xunit.performance.analysis/Writers/CsvResultsWriter.cs",
+    "../../xunit.performance.analysis/Writers/CsvStatsWriter.cs",
+    "../../xunit.performance.analysis/Writers/HtmlResultsWriter.cs",
+    "../../xunit.performance.analysis/Writers/XmlResultsWriter.cs"
   ],
   "dependencies": {
       "Microsoft.NETCore.DotNetHostPolicy":"1.0.1-rc2-002357-00",

--- a/src/xunit.performance.analysis/MathExtensions.cs
+++ b/src/xunit.performance.analysis/MathExtensions.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using MathNet.Numerics;
-using MathNet.Numerics.Statistics;
 using System;
 using System.Collections.Generic;
+#if !LINUX_BUILD
+using MathNet.Numerics;
+using MathNet.Numerics.Statistics;
+#endif
 
 namespace Microsoft.Xunit.Performance.Analysis
 {
+#if !LINUX_BUILD
+
     public static class MathExtensions
     {
         /// <summary>
@@ -46,4 +50,20 @@ namespace Microsoft.Xunit.Performance.Analysis
             return result;
         }
     }
+
+#else
+
+    //
+    // Just mock up the type for build to complete on Linux 
+    //
+    public static class MathExtensions
+    {
+        public static double MarginOfError(this RunningStatistics stats, double confidence)
+        {
+            return 0;
+        }    
+    }
+
+#endif
 }
+

--- a/src/xunit.performance.analysis/Properties.cs
+++ b/src/xunit.performance.analysis/Properties.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class Properties
+    {
+        public const double ErrorConfidence = 0.95; // TODO: make configurable
+
+        public static Dictionary<string, string> AllMetrics = new Dictionary<string, string>();
+
+        /// <summary>
+        /// The name of the Duration metric, as provided by the XML.
+        /// </summary>
+        public const string DurationMetricName = "Duration";
+    }
+}

--- a/src/xunit.performance.analysis/TestIterationResult.cs
+++ b/src/xunit.performance.analysis/TestIterationResult.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class TestIterationResult
+    {
+        public string EtlPath;
+        public string RunId;
+        public string TestName;
+        public int TestIteration;
+        public Dictionary<string, double> MetricValues = new Dictionary<string, double>();
+    }
+}

--- a/src/xunit.performance.analysis/TestResult.cs
+++ b/src/xunit.performance.analysis/TestResult.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class TestResult
+    {
+        public string TestName;
+        public string RunId;
+        public Dictionary<string, TestStatistics> Stats = new Dictionary<string, TestStatistics>();
+        public List<TestIterationResult> Iterations = new List<TestIterationResult>();
+    }
+}

--- a/src/xunit.performance.analysis/TestResultComparison.cs
+++ b/src/xunit.performance.analysis/TestResultComparison.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+
+    internal class TestResultComparison
+    {
+        public string TestName;
+        public TestResult BaselineResult;
+        public TestResult ComparisonResult;
+        public double PercentChange;
+        public double PercentChangeError;
+
+        public double SortChange => (PercentChange > 0) ? Math.Max(PercentChange - PercentChangeError, 0) : Math.Min(PercentChange + PercentChangeError, 0);
+
+        public bool? Passed
+        {
+            get
+            {
+                if (PercentChange > 0 && PercentChange > PercentChangeError)
+                    return false;
+                if (PercentChange < 0 && PercentChange < -PercentChangeError)
+                    return true;
+                else
+                    return null;
+            }
+        }
+    }
+}

--- a/src/xunit.performance.analysis/TestStatistics.cs
+++ b/src/xunit.performance.analysis/TestStatistics.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 #if !LINUX_BUILD
 using MathNet.Numerics.Statistics;
@@ -127,6 +130,19 @@ namespace Microsoft.Xunit.Performance.Analysis
         {
             values.Add(value);
         }
+
+        public long Count { get; }
+        public double Kurtosis { get; }
+        public double Maximum { get; }
+        public double Mean { get; }
+        public double Minimum { get; }
+        public double PopulationKurtosis { get; }
+        public double PopulationSkewness { get; }
+        public double PopulationStandardDeviation { get; }
+        public double PopulationVariance { get; }
+        public double Skewness { get; }
+        public double StandardDeviation { get; }
+        public double Variance { get; }
     }
 #endif
 }

--- a/src/xunit.performance.analysis/Writers/AbstractResultsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/AbstractResultsWriter.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal abstract class AbstractResultsWriter
+    {
+        protected AbstractResultsWriter(
+                            Dictionary<string, string> allMetrics,
+                            Dictionary<string, Dictionary<string, TestResult>> testResults,
+                            Dictionary<string, List<TestResultComparison>> comparisonResults,
+                            string outputPath)
+        {
+            this.AllMetrics = allMetrics;
+            this.TestResults = testResults;
+            this.ComparisonResults = comparisonResults;
+            this.OutputPath = outputPath;
+
+        }
+
+        internal void Write()
+        {
+            using (this.OutputStream = new StreamWriter( new FileStream(this.OutputPath, FileMode.Create), Encoding.UTF8))
+            {
+                WriteHeader();
+
+                WriteStatistics();
+
+                WriteIndividualResults();
+
+                WriteFooter();
+            }
+        }
+
+
+        protected abstract void WriteHeader();
+
+        protected abstract void WriteFooter();
+
+        protected abstract void WriteStatistics();
+
+        protected abstract void WriteIndividualResults();
+
+        protected Dictionary<string, string> AllMetrics { get; private set; }
+
+        protected Dictionary<string, List<TestResultComparison>> ComparisonResults { get; private set; }
+
+        protected Dictionary<string, Dictionary<string, TestResult>> TestResults { get; private set; }
+
+        protected string OutputPath { get; private set; }
+
+        protected StreamWriter OutputStream { get; private set; }
+    }
+}

--- a/src/xunit.performance.analysis/Writers/CsvResultsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/CsvResultsWriter.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class CsvResultsWriter : CsvStatsWriter
+    {
+        public CsvResultsWriter(Dictionary<string, string> allMetrics,
+                            Dictionary<string, Dictionary<string, TestResult>> testResults,
+                            Dictionary<string, List<TestResultComparison>> comparisonResults,
+                            string outputPath)
+            : base(allMetrics, testResults, comparisonResults, outputPath)
+        {
+        }
+
+        //--//
+
+        protected override void WriteStatistics()
+        {
+        }
+
+        protected override void WriteFooter()
+        {
+        }
+
+        protected override void WriteHeader()
+        {
+        }
+
+        protected override void WriteIndividualResults()
+        {
+            foreach (var run in TestResults)
+            {
+                foreach (var result in run.Value.Values)
+                {
+                    foreach (var iteration in result.Iterations)
+                    {
+                        this.OutputStream.WriteLine(
+                            String.Format("\"{0}\",\"{1}\",\"{2}\",\"{3}\"",
+                                            EscapeCsvString(iteration.RunId),
+                                            EscapeCsvString(iteration.RunId),
+                                            EscapeCsvString(iteration.TestName),
+                                            iteration.MetricValues[Properties.DurationMetricName].ToString()));
+                    }
+
+                }
+            }
+        }
+    }
+}

--- a/src/xunit.performance.analysis/Writers/CsvStatsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/CsvStatsWriter.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class CsvStatsWriter : AbstractResultsWriter
+    {
+        public CsvStatsWriter(Dictionary<string, string> allMetrics,
+                                Dictionary<string, Dictionary<string, TestResult>> testResults,
+                                Dictionary<string, List<TestResultComparison>> comparisonResults,
+                                string outputPath)
+            : base(allMetrics, testResults, comparisonResults, outputPath)
+        {
+        }
+
+        //--//
+
+        protected override void WriteStatistics()
+        {
+            foreach (var run in TestResults)
+            {
+                foreach (var result in run.Value.Values)
+                {
+                    var durationStats = result.Stats[Properties.DurationMetricName].RunningStatistics;
+
+                    this.OutputStream.WriteLine(
+                        "\"{0}\",\"{1}\",\"{2}\",\"{3}\",\"{4}\",\"{5}\",\"{6}\"",
+                        EscapeCsvString(result.TestName),
+                        durationStats.Count,
+                        durationStats.Minimum,
+                        durationStats.Maximum,
+                        durationStats.Mean,
+                        durationStats.StandardDeviation,
+                        EscapeCsvString(GetMetricsString(result.Stats.Keys))
+                        );
+                }
+            }
+        }
+
+        protected override void WriteFooter()
+        {
+        }
+
+        protected override void WriteHeader()
+        {
+            this.OutputStream.WriteLine("Test, Iterations, Duration Min, Duration Max, Duration Average, Duration Stdev, Metrics");
+        }
+
+        protected override void WriteIndividualResults()
+        {
+        }
+
+        protected static string EscapeCsvString(string str)
+        {
+            str.Trim('\"');
+            // Escape the csv string
+            if (str.Contains("\""))
+            {
+                str = str.Replace("\"", "\"\"");
+            }
+
+            if (str.Contains(","))
+            {
+                str = "\"\"" + str + "\"\"";
+            }
+            return str;
+        }
+
+        protected static string GetMetricsString(Dictionary<string, TestStatistics>.KeyCollection metrics)
+        {
+            StringBuilder builder = new StringBuilder();
+            foreach (string metric in metrics)
+            {
+                builder.AppendFormat("{0};", metric);
+            }
+
+            return builder.ToString();
+        }
+    }
+}
+

--- a/src/xunit.performance.analysis/Writers/HtmlResultsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/HtmlResultsWriter.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class HtmlResultsWriter : AbstractResultsWriter
+    {
+        public HtmlResultsWriter(Dictionary<string, string> allMetrics,
+                            Dictionary<string, Dictionary<string, TestResult>> testResults,
+                            Dictionary<string, List<TestResultComparison>> comparisonResults,
+                            string htmlOutputPath)
+            : base(allMetrics, testResults, comparisonResults, htmlOutputPath)
+        {
+        }
+
+        //--//
+
+        protected override void WriteStatistics()
+        {
+            //
+            // Write comparison results
+            //
+            foreach (var metricName in ComparisonResults.Keys)
+            {
+                var comparisonResults = ComparisonResults[metricName];
+
+                this.OutputStream.WriteLine($"<h1>Metric: {metricName}</h1>");
+
+                foreach (var comparison in comparisonResults.GroupBy(r => $"Comparison: {r.ComparisonResult.RunId} | Baseline: {r.BaselineResult.RunId}"))
+                {
+                    this.OutputStream.WriteLine($"<h2>{comparison.Key}</h2>");
+                    this.OutputStream.WriteLine("<table>");
+
+                    this.OutputStream.WriteLine($"<tr><td><b>Test name</b></td><td><b>Change</b></td><td><b>Error</b></td></tr>");
+
+                    foreach (var test in from c in comparison orderby c.SortChange descending select c)
+                    {
+                        var passed = test.Passed;
+
+                        string color;
+                        if (!passed.HasValue)
+                            color = "black";
+                        else if (passed.Value)
+                            color = "green";
+                        else
+                            color = "red";
+
+                        this.OutputStream.WriteLine($"<tr><td>{test.TestName}</td><td><font  color={color}>{test.PercentChange.ToString("+##.#%;-##.#%")}</font></td><td>+/-{test.PercentChangeError.ToString("P1")}</td></tr>");
+                    }
+                    this.OutputStream.WriteLine("</table>");
+                }
+            }
+
+            this.OutputStream.WriteLine("<hr>");
+        }
+
+        protected override void WriteHeader()
+        {
+            this.OutputStream.WriteLine("<html><body>");
+
+            //
+            // List metrics
+            //
+
+            //
+            // A short header to list what metrics have been targeted
+            //
+            this.OutputStream.WriteLine($"<h1>Targeted metrics: </h1>");
+
+            foreach (var metricName in ComparisonResults.Keys)
+            {
+                var comparisonResults = ComparisonResults[metricName];
+
+                this.OutputStream.WriteLine($"<p><b>{metricName}</b>: {comparisonResults.Count} data points</p>");
+            }
+
+            this.OutputStream.WriteLine("<hr>");
+        }
+
+        protected override void WriteFooter()
+        {
+            this.OutputStream.WriteLine("</html></body>");
+        }
+
+        protected override void WriteIndividualResults()
+        {
+            //
+            // Write Individual test results
+            // 
+
+            foreach (var run in TestResults)
+            {
+                this.OutputStream.WriteLine($"<h1>Individual results: {run.Key}</h1>");
+
+                foreach (var metricName in AllMetrics.Keys)
+                {
+                    this.OutputStream.WriteLine($"<h2>Metric: {metricName}</h2>");
+
+                    this.OutputStream.WriteLine($"<table>");
+                    this.OutputStream.WriteLine($"<tr><th>Test</th><th>Unit</th><th>Min</th><th>Mean</th><th>Max</th><th>Margin</th><th>StdDev</th></tr>");
+
+
+                    foreach (var test in run.Value)
+                    {
+                        if (test.Value.Stats.ContainsKey(metricName))
+                        {
+                            var stats = test.Value.Stats[metricName].RunningStatistics;
+                            this.OutputStream.WriteLine($"<tr><td>{test.Value.TestName}</td><td>{AllMetrics[metricName]}</td><td>{stats.Minimum.ToString("G3")}</td><td>{stats.Mean.ToString("G3")}</td><td>{stats.Maximum.ToString("G3")}</td><td>{stats.MarginOfError(Properties.ErrorConfidence).ToString("P1")}</td><td>{stats.StandardDeviation.ToString("G3")}</td></tr>");
+                        }
+                    }
+                    this.OutputStream.WriteLine($"</table>");
+                }
+            }
+        }
+    }
+}

--- a/src/xunit.performance.analysis/Writers/XmlResultsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/XmlResultsWriter.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+#if !LINUX_BUILD
+using MathNet.Numerics.Statistics;
+#endif
+
+namespace Microsoft.Xunit.Performance.Analysis
+{
+    internal class XmlResultsWriter : AbstractResultsWriter
+    {
+        public XmlResultsWriter(
+            Dictionary<string, string> allMetrics,
+            Dictionary<string, Dictionary<string, TestResult>> testResults,
+            Dictionary<string, List<TestResultComparison>> comparisonResults,
+            string outputPath) : base(allMetrics, testResults, comparisonResults, outputPath)
+        {
+        }
+
+        //--//
+
+        protected override void WriteStatistics()
+        {
+        }
+
+        protected override void WriteFooter()
+        {
+        }
+
+        protected override void WriteHeader()
+        {
+        }
+
+        protected override void WriteIndividualResults()
+        {
+            var resultElem = new XElement("results");
+            var xmlDoc = new XDocument(resultElem);
+
+            foreach (var run in TestResults)
+            {
+                var runIdElem = new XElement("run", new XAttribute("id", run.Key));
+                resultElem.Add(runIdElem);
+
+                foreach (var result in run.Value.Values)
+                {
+                    var testElem = new XElement("test", new XAttribute("name", result.TestName));
+                    runIdElem.Add(testElem);
+
+                    var summaryElem = new XElement("summary");
+                    testElem.Add(summaryElem);
+
+                    foreach (var stat in result.Stats)
+                    {
+                        RunningStatistics runningStats = stat.Value.RunningStatistics;
+                        summaryElem.Add(new XElement(stat.Key,
+                            new XAttribute("min", runningStats.Minimum.ToString("G3")),
+                            new XAttribute("mean", runningStats.Mean.ToString("G3")),
+                            new XAttribute("max", runningStats.Maximum.ToString("G3")),
+                            new XAttribute("marginOfError", runningStats.MarginOfError(Properties.ErrorConfidence).ToString("G3")),
+                            new XAttribute("stddev", runningStats.StandardDeviation.ToString("G3"))));
+                    }
+                }
+            }
+
+            //
+            // Write comparison results
+            //
+            foreach (var metricName in ComparisonResults.Keys)
+            {
+                var comparisonResults = ComparisonResults[metricName];
+
+                foreach (var comparison in comparisonResults)
+                {
+                    var comparisonElem = new XElement("comparison", new XAttribute("test", comparison.TestName), new XAttribute("baselineId", comparison.BaselineResult.RunId), new XAttribute("comparisonId", comparison.ComparisonResult.RunId));
+                    resultElem.Add(comparisonElem);
+
+                    comparisonElem.Add(
+                        new XElement(metricName,
+                        new XAttribute("changeRatio", comparison.PercentChange.ToString("G3")),
+                        new XAttribute("changeRatioError", comparison.PercentChangeError.ToString("G3"))));
+                }
+            }
+
+            xmlDoc.Save(this.OutputStream);
+        }
+    }
+}

--- a/src/xunit.performance.analysis/xunit.performance.analysis.csproj
+++ b/src/xunit.performance.analysis/xunit.performance.analysis.csproj
@@ -55,6 +55,15 @@
     <Compile Include="..\common\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Properties.cs" />
+    <Compile Include="Writers\AbstractResultsWriter.cs" />
+    <Compile Include="TestIterationResult.cs" />
+    <Compile Include="TestResultComparison.cs" />
+    <Compile Include="TestResult.cs" />
+    <Compile Include="Writers\CsvStatsWriter.cs" />
+    <Compile Include="Writers\CsvResultsWriter.cs" />
+    <Compile Include="Writers\XmlResultsWriter.cs" />
+    <Compile Include="Writers\HtmlResultsWriter.cs" />
     <Compile Include="MathExtensions.cs" />
     <Compile Include="Microsoft-Xunit-Benchmark.manifest.cs" />
     <Compile Include="Program.cs" />


### PR DESCRIPTION
Refactored xunit performance analysis tool to show existing, minimal statistical analysis for all observed metrics. 
Created extensible writers for all currently used file formats.
Small addition to .gitignore

Code that writes to .csv, .xml and .http file formats has moved to the writers. The .html writer includes a small header to list all collected metrics and data points available for each metric. Observed metrics are collected at when ETW logs are parsed, and statistics are computed for all observed metrics, if data points are available.