### PR TITLE
Fixing build breaks caused due to cli install failures

### DIFF
--- a/BuildCliComponents.cmd
+++ b/BuildCliComponents.cmd
@@ -28,7 +28,7 @@ set Init_Tools_Log=%DotNet_Path%\install.log
 if NOT exist "%DotNet_Path%" mkdir "%DotNet_Path%"
 
 set /p DotNet_Version=< %~dp0DotNetCLIVersion.txt
-set DotNet_Installer_Url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1
+set DotNet_Installer_Url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.ps1
 
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "Invoke-WebRequest -Uri '%DotNet_Installer_Url%' -OutFile '%DotNet_Path%\dotnet-install.ps1'"
 echo Executing dotnet installer script %DotNet_Path%\dotnet-install.ps1

--- a/BuildCliComponents.sh
+++ b/BuildCliComponents.sh
@@ -17,7 +17,7 @@ declare currentDir=`pwd`
 declare outputDirectory=${currentDir}/LocalPackages
 declare dotnetPath=${currentDir}/tools/bin/ubuntu
 declare dotnetCmd=${dotnetPath}/dotnet
-declare dotnetInstallerUrl=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
+declare dotnetInstallerUrl=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh
 declare dotnetInstallerScript=${dotnetPath}/dotnet-install.sh
 declare dotnetVersion=`cat DotNetCliVersion.txt`
 
@@ -28,7 +28,7 @@ then
 	then
 		mkdir -p $dotnetPath
 	fi
-	
+
 	curl $dotnetInstallerUrl -o $dotnetInstallerScript
 	chmod +x $dotnetInstallerScript
 


### PR DESCRIPTION
Installation of old cli versions is supported by scripts under the preview1 branch of dotnet cli, using this to download our cli version so our build is not broken
https://github.com/dotnet/cli/issues/3152
@lt72 @brianrob 