### PR TITLE
Update performance runners to restore for netstandard1.3

### DIFF
--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.35
-set BuildSemanticVersion=1.0.0-alpha-build0035
+set BuildAssemblyVersion=1.0.0.36
+set BuildSemanticVersion=1.0.0-alpha-build0036
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="Locally built packages" value="LocalPackages" />
+    <add key="dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />

--- a/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
+++ b/src/cli/Microsoft.DotNet.xunit.performance.runner.cli/project.json
@@ -20,7 +20,8 @@
     "Microsoft.DotNet.xunit.performance.run.core": "99.99.99-dev",
     "Microsoft.NETCore.DotNetHostPolicy":"1.0.1-rc2-002357-00",
     "NETStandard.Library": "1.5.0-rc2-23931",
-    "xunit.extensibility.execution": "2.1.0"
+    "Microsoft.xunit.extensibility.execution.netcore": "1.0.0-prerelease-00508-01",
+    "System.Diagnostics.Process": "4.1.0-rc2-24103",
   },
   "__comment": "netcoreapp1.0 import and the runtime below is a hack, we need CLI to allow us to build issue reference: https://github.com/dotnet/cli/issues/2913",
   "frameworks": {

--- a/src/xunit.performance.nuspec
+++ b/src/xunit.performance.nuspec
@@ -39,6 +39,25 @@
         <dependency id="xunit.extensibility.core" version="2.1.0" />
         <dependency id="xunit.extensibility.execution" version="2.1.0" />
       </group>
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
+        <dependency id="System.Diagnostics.Tracing" version="4.0.20" />
+        <dependency id="System.Globalization" version="4.0.10" />
+        <dependency id="System.IO" version="4.0.10" />
+        <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime.Extensions" version="4.0.10" />
+        <dependency id="System.Text.Encoding" version="4.0.10" />
+        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Threading.Tasks" version="4.0.10" />
+        <dependency id="xunit.abstractions" version="2.0.0" />
+        <dependency id="xunit.extensibility.core" version="2.1.0" />
+        <dependency id="xunit.extensibility.execution" version="2.1.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -48,6 +67,12 @@
     <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.xml" target="lib\dotnet\" />
     <file src="xunit.performance.execution.dotnet\bin\$Configuration$\xunit.performance.execution.dotnet.dll" target="lib\dotnet\" />
     <file src="xunit.performance.execution.dotnet\bin\$Configuration$\xunit.performance.execution.dotnet.pdb" target="lib\dotnet\" />
+    <!-- For netstandard targetted projects -->
+    <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.dll" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.pdb" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.xml" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.execution.dotnet\bin\$Configuration$\xunit.performance.execution.dotnet.dll" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.execution.dotnet\bin\$Configuration$\xunit.performance.execution.dotnet.pdb" target="lib\netstandard1.3\" />
     <!-- For desktop class library projects -->
     <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.dll" target="lib\net46\" />
     <file src="xunit.performance.core\bin\$Configuration$\xunit.performance.core.pdb" target="lib\net46\" />

--- a/src/xunit.performance.run.core.nuspec
+++ b/src/xunit.performance.run.core.nuspec
@@ -31,12 +31,34 @@ Contains the core portable functionality used by xunit.performance.run.
         <dependency id="xunit.abstractions" version="2.0.0" />
         <dependency id="xunit.runner.utility" version="2.1.0" />
       </group>
+      <group targetFramework="netstandard1.3">
+        <dependency id="System.Threading" version="4.0.10" />
+        <dependency id="System.Collections" version="4.0.10" />
+        <dependency id="System.Console" version="4.0.0-beta-23225" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
+        <dependency id="System.Diagnostics.Process" version="4.0.0-beta-23225" />
+        <dependency id="System.IO" version="4.0.10" />
+        <dependency id="System.IO.FileSystem" version="4.0.0" />
+        <dependency id="System.Linq" version="4.0.0" />
+        <dependency id="System.Reflection" version="4.0.10" />
+        <dependency id="System.Runtime" version="4.0.20" />
+        <dependency id="System.Runtime.Extensions" version="4.0.10" />
+        <dependency id="System.Xml.XDocument" version="4.0.10" />
+        <dependency id="xunit.abstractions" version="2.0.0" />
+        <dependency id="xunit.runner.utility" version="2.1.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>
+    <!-- For portable class library or DNX projects -->
     <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.core.dll" target="lib\dotnet\" />
     <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.run.core.dll" target="lib\dotnet\" />
     <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.run.core.pdb" target="lib\dotnet\" />
     <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.core.pdb" target="lib\dotnet\" />
+    <!-- for netstandard targetted projects -->
+    <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.core.dll" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.run.core.dll" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.run.core.pdb" target="lib\netstandard1.3\" />
+    <file src="xunit.performance.run.core\bin\$Configuration$\xunit.performance.core.pdb" target="lib\netstandard1.3\" />
   </files>
 </package>


### PR DESCRIPTION
This change updates the perf libraries to restore for netstandard1.3.

This involves them consuming the repackaged xunit libraries from buildtools and is dependent on PR https://github.com/dotnet/buildtools/pull/770 . I have made the Microsoft.xunit.extensibility.execution.netcore dependency versionless so that it will pick up the most recent copy(we shouldn't any updates to this package ever - this is simply a workaround until xunit ships with rc2 support).

/cc @dsgouda @brianrob @ericstj 