### PR TITLE
Fixing cli runner dependencies

### DIFF
--- a/src/xunit.performance.run.core.nuspec
+++ b/src/xunit.performance.run.core.nuspec
@@ -18,9 +18,9 @@ Contains the core portable functionality used by xunit.performance.run.
       <group targetFramework="dotnet">
         <dependency id="System.Threading" version="4.0.10" />
         <dependency id="System.Collections" version="4.0.10" />
-        <dependency id="System.Console" version="4.0.0-beta-23225" />
+        <dependency id="System.Console" version="4.0.0-rc2-24103" />
         <dependency id="System.Diagnostics.Debug" version="4.0.10" />
-        <dependency id="System.Diagnostics.Process" version="4.0.0-beta-23225" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0-rc2-24103" />
         <dependency id="System.IO" version="4.0.10" />
         <dependency id="System.IO.FileSystem" version="4.0.0" />
         <dependency id="System.Linq" version="4.0.0" />


### PR DESCRIPTION
Revving System.Diagnostics.Process dependencies in xunit performance since the older version indirectly references a windows-only dll and cannot be run on linux
This fixes current perf runs on linux

@brianrob @lt72 