### PR TITLE
Update nuget reference

### DIFF
--- a/xunit.performance.msbuild
+++ b/xunit.performance.msbuild
@@ -119,7 +119,7 @@
 
               Log.LogMessage("Downloading latest version of NuGet.exe...");
               WebClient webClient = new WebClient();
-              webClient.DownloadFile("http://dist.nuget.org/win-x86-commandline/v3.1.0-beta/nuget.exe", OutputFilename);
+              webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFilename);
 
               return true;
           }


### PR DESCRIPTION
We had a hard link on an old version of nuget that didn't work with the netstandard profile when creating nuget packages. 