### PR TITLE
Remove xunit dependency from nuspec for netstandard and use the new buildtools package

### DIFF
--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.36
-set BuildSemanticVersion=1.0.0-alpha-build0036
+set BuildAssemblyVersion=1.0.0.37
+set BuildSemanticVersion=1.0.0-alpha-build0037
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/src/xunit.performance.nuspec
+++ b/src/xunit.performance.nuspec
@@ -54,9 +54,7 @@
         <dependency id="System.Text.Encoding" version="4.0.10" />
         <dependency id="System.Threading" version="4.0.10" />
         <dependency id="System.Threading.Tasks" version="4.0.10" />
-        <dependency id="xunit.abstractions" version="2.0.0" />
-        <dependency id="xunit.extensibility.core" version="2.1.0" />
-        <dependency id="xunit.extensibility.execution" version="2.1.0" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.performance.run.core.nuspec
+++ b/src/xunit.performance.run.core.nuspec
@@ -44,8 +44,7 @@ Contains the core portable functionality used by xunit.performance.run.
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />
         <dependency id="System.Xml.XDocument" version="4.0.10" />
-        <dependency id="xunit.abstractions" version="2.0.0" />
-        <dependency id="xunit.runner.utility" version="2.1.0" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This is to remove the xunit dependencies preventing restore for netstandard. This will only affect the netstandard section of the nuspec.

/cc @dsgouda @brianrob 