### PR TITLE
Packaging executables under lib for nuget resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+LocalPackages/
 
 # Tools
 tools/

--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.37
-set BuildSemanticVersion=1.0.0-alpha-build0037
+set BuildAssemblyVersion=1.0.0.39
+set BuildSemanticVersion=1.0.0-alpha-build0039
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/src/xunit.performance.analysis.nuspec
+++ b/src/xunit.performance.analysis.nuspec
@@ -16,10 +16,10 @@ Contains the tools necessary for analyzing the output of xunit Performance tests
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
   <files>
-    <file src="xunit.performance.analysis\bin\$Configuration$\MathNet.Numerics.dll" target="tools\" />
-    <file src="xunit.performance.analysis\bin\$Configuration$\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="tools\" />
-    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.exe" target="tools\" />
-    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.exe.config" target="tools\" />
-    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.pdb" target="tools\" />
+    <file src="xunit.performance.analysis\bin\$Configuration$\MathNet.Numerics.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.analysis\bin\$Configuration$\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.exe" target="lib\netstandard1.3" />
+    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.exe.config" target="lib\netstandard1.3" />
+    <file src="xunit.performance.analysis\bin\$Configuration$\xunit.performance.analysis.pdb" target="lib\netstandard1.3" />
   </files>
 </package>

--- a/src/xunit.performance.nuspec
+++ b/src/xunit.performance.nuspec
@@ -54,7 +54,7 @@
         <dependency id="System.Text.Encoding" version="4.0.10" />
         <dependency id="System.Threading" version="4.0.10" />
         <dependency id="System.Threading.Tasks" version="4.0.10" />
-        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-00508-01" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.performance.run.core.nuspec
+++ b/src/xunit.performance.run.core.nuspec
@@ -44,7 +44,7 @@ Contains the core portable functionality used by xunit.performance.run.
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />
         <dependency id="System.Xml.XDocument" version="4.0.10" />
-        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-00508-01" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.performance.runner.Windows.nuspec
+++ b/src/xunit.performance.runner.Windows.nuspec
@@ -19,26 +19,26 @@ Contains the tools necessary for running xunit Performance tests in Windows usin
     </dependencies>
   </metadata>
   <files>
-    <file src="xunit.performance.run\bin\$Configuration$\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\ProcDomain.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\ProcDomain.pdb" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.abstractions.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.core.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.core.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.core.pdb" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.logger.exe" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.logger.pdb" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.metrics.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.metrics.pdb" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.exe" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.exe.config" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.pdb" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.dll" target="tools\" />
-    <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.pdb" target="tools\" />
+    <file src="xunit.performance.run\bin\$Configuration$\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\ProcDomain.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\ProcDomain.pdb" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.abstractions.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.core.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.core.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.core.pdb" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.logger.exe" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.logger.pdb" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.metrics.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.metrics.pdb" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.exe" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.exe.config" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.performance.run.pdb" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.dll" target="lib\netstandard1.3" />
+    <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.pdb" target="lib\netstandard1.3" />
     <!-- Pick up the following directly from the nuget because they're not copied to bin\Release in non-DesignTimeBuild builds -->
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\KernelTraceControl.dll" target="tools\x86\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\msdia140.dll" target="tools\x86\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\KernelTraceControl.dll" target="tools\amd64\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\msdia140.dll" target="tools\amd64\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\KernelTraceControl.dll" target="lib\netstandard1.3\x86\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\msdia140.dll" target="lib\netstandard1.3\x86\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\KernelTraceControl.dll" target="lib\netstandard1.3\amd64\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\msdia140.dll" target="lib\netstandard1.3\amd64\" />
   </files>
 </package>

--- a/src/xunit.performance.runner.Windows.nuspec
+++ b/src/xunit.performance.runner.Windows.nuspec
@@ -36,9 +36,9 @@ Contains the tools necessary for running xunit Performance tests in Windows usin
     <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.dll" target="lib\netstandard1.3" />
     <file src="xunit.performance.run\bin\$Configuration$\xunit.runner.utility.desktop.pdb" target="lib\netstandard1.3" />
     <!-- Pick up the following directly from the nuget because they're not copied to bin\Release in non-DesignTimeBuild builds -->
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\KernelTraceControl.dll" target="lib\netstandard1.3\x86\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\msdia140.dll" target="lib\netstandard1.3\x86\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\KernelTraceControl.dll" target="lib\netstandard1.3\amd64\" />
-    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\msdia140.dll" target="lib\netstandard1.3\amd64\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\KernelTraceControl.dll" target="runtimes\win7-x86\native\x86\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\x86\msdia140.dll" target="runtimes\win7-x86\native\x86\"/>
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\KernelTraceControl.dll" target="runtimes\win7-x64\native\amd64\" />
+    <file src="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.39\lib\native\amd64\msdia140.dll" target="runtimes\win7-x64\native\amd64\" />
   </files>
 </package>


### PR DESCRIPTION
This allows Nuget package resolution tasks under build tools to correctly bring down the windows version of xunit perf runner as a dependency for perf tests during execution, also eliminates the need to package xunit perf runner as a supplemental payload for helix runs

@MattGal @lt72 