### PR TITLE
Adding multi metric support to xunit perf analysis

### DIFF
--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.37
-set BuildSemanticVersion=1.0.0-alpha-build0037
+set BuildAssemblyVersion=1.0.0.39
+set BuildSemanticVersion=1.0.0-alpha-build0039
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/src/xunit.performance.analysis/Properties.cs
+++ b/src/xunit.performance.analysis/Properties.cs
@@ -15,5 +15,9 @@ namespace Microsoft.Xunit.Performance.Analysis
         /// The name of the Duration metric, as provided by the XML.
         /// </summary>
         public const string DurationMetricName = "Duration";
+        public const string GCAllocMetricName = "GCAlloc";
+        public const string GCCountMetricName = "GCCount";
+        public const string InstRetiredMetricName = "InstRetired";
+
     }
 }

--- a/src/xunit.performance.analysis/Writers/CsvResultsWriter.cs
+++ b/src/xunit.performance.analysis/Writers/CsvResultsWriter.cs
@@ -3,17 +3,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Xunit.Performance.Analysis
 {
     internal class CsvResultsWriter : CsvStatsWriter
     {
+        private string MetricName;
         public CsvResultsWriter(Dictionary<string, string> allMetrics,
                             Dictionary<string, Dictionary<string, TestResult>> testResults,
                             Dictionary<string, List<TestResultComparison>> comparisonResults,
-                            string outputPath)
-            : base(allMetrics, testResults, comparisonResults, outputPath)
+                            string outputPath, string metricName)
+            : base(allMetrics, testResults, comparisonResults, Path.Combine(outputPath, metricName+".csv"))
         {
+            this.MetricName = metricName;
         }
 
         //--//
@@ -38,16 +41,22 @@ namespace Microsoft.Xunit.Performance.Analysis
                 {
                     foreach (var iteration in result.Iterations)
                     {
+                        // If the current iteration does not contain this metric, skip
+                        if (!iteration.MetricValues.ContainsKey(this.MetricName))
+                            continue;
+
                         this.OutputStream.WriteLine(
                             String.Format("\"{0}\",\"{1}\",\"{2}\",\"{3}\"",
                                             EscapeCsvString(iteration.RunId),
                                             EscapeCsvString(iteration.RunId),
                                             EscapeCsvString(iteration.TestName),
-                                            iteration.MetricValues[Properties.DurationMetricName].ToString()));
+                                            iteration.MetricValues[this.MetricName].ToString()));
+
                     }
 
                 }
             }
         }
+
     }
 }

--- a/src/xunit.performance.nuspec
+++ b/src/xunit.performance.nuspec
@@ -54,7 +54,7 @@
         <dependency id="System.Text.Encoding" version="4.0.10" />
         <dependency id="System.Threading" version="4.0.10" />
         <dependency id="System.Threading.Tasks" version="4.0.10" />
-        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-00508-01" />
       </group>
     </dependencies>
   </metadata>

--- a/src/xunit.performance.run.core.nuspec
+++ b/src/xunit.performance.run.core.nuspec
@@ -44,7 +44,7 @@ Contains the core portable functionality used by xunit.performance.run.
         <dependency id="System.Runtime" version="4.0.20" />
         <dependency id="System.Runtime.Extensions" version="4.0.10" />
         <dependency id="System.Xml.XDocument" version="4.0.10" />
-        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-508-01" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease-00508-01" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Enabling generation of multi-metric csvs which can then be displayed on benchview.
Generating one csv file per metric as per benchview specs
fixing some dependencies in nuspec files
@lt72 

P.S.: There is some testing pending however this does generate the appropriate csv files from test results xml.
This also needs fixing of the version number