### PR TITLE
Fix InstructionsRetired Reports (Missing Data)

### DIFF
--- a/NightlyBuild.cmd
+++ b/NightlyBuild.cmd
@@ -19,8 +19,8 @@ bump the build number on BuildSemanticVersion below.
 :main
 setlocal
 
-set BuildAssemblyVersion=1.0.0.40
-set BuildSemanticVersion=1.0.0-alpha-build0040
+set BuildAssemblyVersion=1.0.0.41
+set BuildSemanticVersion=1.0.0-alpha-build0041
 set OutputDirectory=%~dp0LocalPackages
 set DotNet=%~dp0\tools\cli\bin\dotnet
 

--- a/src/xunit.performance.analysis/TestStatistics.cs
+++ b/src/xunit.performance.analysis/TestStatistics.cs
@@ -87,8 +87,13 @@ namespace Microsoft.Xunit.Performance.Analysis
             double[] newValues = new double[newArrayLength];
             Array.Copy(values, startIndex, newValues, 0, newArrayLength);
 
-            // Swap in the updated set of values.
-            _values = new List<double>(newValues);
+            // Ensure that we've not thrown out too much data.
+            // The cap here is 5%.
+            if (newValues.Length >= _values.Count / 20)
+            {
+                // Swap in the updated set of values.
+                _values = new List<double>(newValues);
+            }
         }
 
         private static double PercentileInSortedArray(double[] values, int percentage)


### PR DESCRIPTION
The instructions retired data was being thrown away because there were only 2 values across all iterations.  Our outlier analysis threw them out.

This change ensures that we don't throw away more than 5% of data - if we feel we need to then we don't throw any away.

@dsgouda, PTAL