### PR TITLE
Linux: Fixing exception.

### DIFF
--- a/src/xunit.performance.run/ProgramCore.cs
+++ b/src/xunit.performance.run/ProgramCore.cs
@@ -184,7 +184,9 @@ Arguments: {startInfo.Arguments}");
 
             using (var evaluationContext = logger.GetReader())
             {
-                var xmlDoc = XDocument.Load(xmlPath);
+                var fullPath = Path.GetFullPath(xmlPath);
+                var uri = new Uri(fullPath);
+                var xmlDoc = XDocument.Load(uri.AbsoluteUri);
                 foreach (var testElem in xmlDoc.Descendants("test"))
                 {
                     var testName = testElem.Attribute("name").Value;
@@ -512,7 +514,7 @@ Valid options:
   -runner ""name""         : use the specified runner to excecute tests. Defaults
                          : to xunit.console.exe
   -runnerargs ""args""     : append the given args to the end of the xunit runner's command-line
-                         : a quoted group of arguments, 
+                         : a quoted group of arguments,
                          : e.g. -runnerargs ""-verbose -nologo -parallel none""
   -runid ""name""          : a run identifier used to create unique output filenames.
   -outdir ""name""         : folder for output files.

--- a/src/xunit.performance.run/XunitPerformanceProject.cs
+++ b/src/xunit.performance.run/XunitPerformanceProject.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace Microsoft.Xunit.Performance
@@ -30,7 +31,7 @@ namespace Microsoft.Xunit.Performance
 
         public string RunId { get; set; } = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss");
 
-        public string OutputDir { get; set; } = ".";
+        public string OutputDir { get; set; } = Directory.GetCurrentDirectory();
 
         private string _outputBaseFileName;
         public string OutputBaseFileName {


### PR DESCRIPTION
"Invalid URI: The format of the URI could not be determined." exception was caused by passing a relative path to load the xml.
