### PR TITLE
Add back strong name signing

### DIFF
--- a/src/common/GlobalAssemblyInfo.cs
+++ b/src/common/GlobalAssemblyInfo.cs
@@ -3,8 +3,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("xUnit Performance Testing Framework")]
 [assembly: AssemblyCopyright("Copyright \u00A9 Microsoft Corporation 2015")]
-[assembly: AssemblyVersion("99.99.99.0")]
-[assembly: AssemblyInformationalVersion("99.99.99-dev")]
+[assembly: AssemblyKeyFileAttribute("..\\Common\\xunit.performance.snk")]

--- a/src/xunit.performance.analysis/xunit.performance.analysis.csproj
+++ b/src/xunit.performance.analysis/xunit.performance.analysis.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
   <ItemGroup>

--- a/src/xunit.performance.core/xunit.performance.core.csproj
+++ b/src/xunit.performance.core/xunit.performance.core.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/src/xunit.performance.execution/Properties/AssemblyInfo.cs
+++ b/src/xunit.performance.execution/Properties/AssemblyInfo.cs
@@ -5,7 +5,16 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: Xunit.Sdk.PlatformSpecificAssembly]
-[assembly: InternalsVisibleTo("xunit.performance.api")]
+[assembly: InternalsVisibleTo("xunit.performance.api, PublicKey=00240000048000009400000006020000" +
+																"00240000525341310004000001000100" +
+																"99B48762D2238A6917BBBFF1DC9787FA" +
+																"10251039B421C621FB37F6C539B912BB" +
+																"69627FBED5B0C267FCC68750448107DC" +
+																"D5D6DA22B6DDCAF2D96037F3BBF5030B" +
+																"D1C33474402F369735B0615C0CE6FACE" +
+																"3B9033A979BC4EBC504773C60E5F48A0" +
+																"B09B18B5806BCCC12C03858C0141E0E5" +
+																"270E48830EBFAEC006071BD2830559E2")]
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/src/xunit.performance.logger/xunit.performance.logger.csproj
+++ b/src/xunit.performance.logger/xunit.performance.logger.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/src/xunit.performance.run/xunit.performance.run.csproj
+++ b/src/xunit.performance.run/xunit.performance.run.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" />
+	<Compile Include="..\common\GlobalAssemblyInfo.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>


### PR DESCRIPTION
When we made the transition to use dotnet cli to build the project we
stopped strong name signing the resulting binaries.  This caused a
problem when we try and use these binaries to build our perf tests in
the CoreFX repo.  To fix this problem we just use the
GlobablAssemblyInfo file to apply the key to all of the projects.  We
also neede to update the AssemblyInfo of the execution project because
it allows the api project to view its internal state and since the
binaries are now strong name signed we need to include the public key.