### PR TITLE
Adding a Ctrl-C, Ctrl-Break, Close handle for disposable objects.

### DIFF
--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers;
 using Microsoft.Diagnostics.Tracing.Session;
-using Microsoft.Xunit.Performance.Api.Table;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Xunit.Performance.Api
             var needKernelSession = NeedSeparateKernelSession(kernelProviderInfo);
             using (var safeKernelSession = needKernelSession ? MakeSafeTerminateTraceEventSession(KernelTraceEventParser.KernelSessionName, kernelFullFileName) : null)
             {
-                var kernelSession = safeKernelSession.BaseDisposableObject;
+                var kernelSession = safeKernelSession?.BaseDisposableObject;
                 if (kernelSession != null)
                 {
                     SetPreciseMachineCounters(providers);
@@ -213,7 +213,7 @@ namespace Microsoft.Xunit.Performance.Api
 
             // CPU counters need the special kernel session
             var keywords = (KernelTraceEventParser.Keywords)kernelProviderInfo.Keywords & KernelTraceEventParser.Keywords.PMCProfile;
-            return (keywords != 0);
+            return (keywords != KernelTraceEventParser.Keywords.None);
         }
 
         private static bool IsWindows8OrGreater => IsWindows8OrGreater();

--- a/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
+++ b/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
@@ -8,9 +8,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
 using Microsoft.Xunit.Performance.Sdk;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {

--- a/src/xunit.performance.api/Kernel32.cs
+++ b/src/xunit.performance.api/Kernel32.cs
@@ -87,5 +87,22 @@ namespace Microsoft.Xunit.Performance.Api.Native.Windows
             ulong dwlConditionMask,
             TypeMask dwTypeBitMask,
             ConditionMask dwConditionMask);
+
+        [Flags]
+        public enum CtrlTypes : uint
+        {
+            CTRL_C_EVENT = 0,
+            CTRL_BREAK_EVENT = 1,
+            CTRL_CLOSE_EVENT = 2,
+            CTRL_LOGOFF_EVENT = 5,
+            CTRL_SHUTDOWN_EVENT = 6
+        }
+
+        public delegate bool PHANDLER_ROUTINE(CtrlTypes dwCtrlType);
+
+        [DllImport("kernel32.dll", SetLastError = true, CallingConvention = CallingConvention.Winapi)]
+        public static extern bool SetConsoleCtrlHandler(
+            [In, MarshalAs(UnmanagedType.FunctionPtr)]PHANDLER_ROUTINE HandlerRoutine,
+            bool Add);
     }
 }

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -3,6 +3,15 @@ using System;
 
 namespace Microsoft.Xunit.Performance.Api
 {
+    /// <summary>
+    /// Provides a mechanism for releasing disposable resources when CTRL+C,
+    /// CTRL+BREAK, or Close event (when the user closes the console by either
+    /// clicking Close on the console windows's window menu, or by clicking the
+    /// "End Task" button on the Task Manager) signals are received by the
+    /// application.
+    /// </summary>
+    /// <remarks>This class it is currently adding support for Windows only.</remarks>
+    /// <typeparam name="T"></typeparam>
     internal sealed class SafeTerminateHandler<T> : IDisposable
         where T : class, IDisposable
     {
@@ -19,8 +28,7 @@ namespace Microsoft.Xunit.Performance.Api
                     case Kernel32.CtrlTypes.CTRL_CLOSE_EVENT:
                         BaseDisposableObject?.Dispose();
                         break;
-                    case Kernel32.CtrlTypes.CTRL_LOGOFF_EVENT:
-                    case Kernel32.CtrlTypes.CTRL_SHUTDOWN_EVENT:
+                    default:
                         break;
                 }
                 return false;
@@ -45,20 +53,18 @@ namespace Microsoft.Xunit.Performance.Api
             {
                 if (disposing)
                 {
-                    // TODO: dispose managed state (managed objects).
                     BaseDisposableObject?.Dispose();
                 }
 
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
                 if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, false))
+                {
                     throw new ObjectDisposedException("SetConsoleCtrlHandler failed to remove handler.");
+                }
 
                 _disposedValue = true;
             }
         }
 
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
         ~SafeTerminateHandler()
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
@@ -70,7 +76,6 @@ namespace Microsoft.Xunit.Performance.Api
         {
             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
             Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
             GC.SuppressFinalize(this);
         }
         #endregion

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -44,12 +44,11 @@ namespace Microsoft.Xunit.Performance.Api
                 return false;
             };
 
-            if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, true))
-                throw new Exception("SetConsoleCtrlHandler failed to add handler.");
-
             lock (_lock)
             {
                 _disposedValue = false;
+                if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, true))
+                    throw new Exception("SetConsoleCtrlHandler failed to add handler.");
                 BaseDisposableObject = createCallback();
             }
         }

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Xunit.Performance.Api.Native.Windows;
+using System;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class SafeTerminateHandler<T> : IDisposable
+        where T : class, IDisposable
+    {
+        public SafeTerminateHandler(Func<T> createCallback)
+        {
+            BaseDisposableObject = null;
+
+            _HandlerRoutine = (Kernel32.CtrlTypes dwCtrlType) =>
+            {
+                switch (dwCtrlType)
+                {
+                    case Kernel32.CtrlTypes.CTRL_C_EVENT:
+                    case Kernel32.CtrlTypes.CTRL_BREAK_EVENT:
+                    case Kernel32.CtrlTypes.CTRL_CLOSE_EVENT:
+                        BaseDisposableObject?.Dispose();
+                        break;
+                    case Kernel32.CtrlTypes.CTRL_LOGOFF_EVENT:
+                    case Kernel32.CtrlTypes.CTRL_SHUTDOWN_EVENT:
+                        break;
+                }
+                return false;
+            };
+
+            if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, true))
+                throw new Exception("SetConsoleCtrlHandler failed to add handler.");
+
+            BaseDisposableObject = createCallback();
+        }
+
+        public T BaseDisposableObject { get; }
+
+        private readonly Kernel32.PHANDLER_ROUTINE _HandlerRoutine;
+
+        #region IDisposable Support
+        private bool _disposedValue = false; // To detect redundant calls
+
+        void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    BaseDisposableObject?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+                if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, false))
+                    throw new ObjectDisposedException("SetConsoleCtrlHandler failed to remove handler.");
+
+                _disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        ~SafeTerminateHandler()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(false);
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -10,15 +10,25 @@ namespace Microsoft.Xunit.Performance.Api
     /// "End Task" button on the Task Manager) signals are received by the
     /// application.
     /// </summary>
-    /// <remarks>This class it is currently adding support for Windows only.</remarks>
-    /// <typeparam name="T"></typeparam>
+    /// <remarks>
+    /// 1. This class it is currently adding support for Windows only.
+    /// 2. This class owns the Disposable object that is being wrapped, and it is responsible for its cleanup.
+    /// </remarks>
+    /// <typeparam name="T">The type that this class encapsulates.</typeparam>
     internal sealed class SafeTerminateHandler<T> : IDisposable
         where T : class, IDisposable
     {
+        /// <summary>
+        /// Initializes a new instance of the SafeTerminateHandler<T> class that
+        /// wraps a disposable object that will be created by calling the
+        /// specified callback Func.
+        /// </summary>
+        /// <param name="createCallback">A method that has no parameters and returns a new disposable object of the type specified by the T parameter.</param>
         public SafeTerminateHandler(Func<T> createCallback)
         {
+            _disposedValue = true;
+            _lock = new object();
             BaseDisposableObject = null;
-
             _HandlerRoutine = (Kernel32.CtrlTypes dwCtrlType) =>
             {
                 switch (dwCtrlType)
@@ -26,7 +36,7 @@ namespace Microsoft.Xunit.Performance.Api
                     case Kernel32.CtrlTypes.CTRL_C_EVENT:
                     case Kernel32.CtrlTypes.CTRL_BREAK_EVENT:
                     case Kernel32.CtrlTypes.CTRL_CLOSE_EVENT:
-                        BaseDisposableObject?.Dispose();
+                        Dispose();
                         break;
                     default:
                         break;
@@ -37,31 +47,42 @@ namespace Microsoft.Xunit.Performance.Api
             if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, true))
                 throw new Exception("SetConsoleCtrlHandler failed to add handler.");
 
-            BaseDisposableObject = createCallback();
+            lock (_lock)
+            {
+                _disposedValue = false;
+                BaseDisposableObject = createCallback();
+            }
         }
 
         public T BaseDisposableObject { get; }
 
         private readonly Kernel32.PHANDLER_ROUTINE _HandlerRoutine;
+        private readonly object _lock;
 
         #region IDisposable Support
-        private bool _disposedValue = false; // To detect redundant calls
+        private volatile bool _disposedValue; // To detect redundant calls
 
         void Dispose(bool disposing)
         {
             if (!_disposedValue)
             {
-                if (disposing)
+                lock (_lock)
                 {
-                    BaseDisposableObject?.Dispose();
-                }
+                    if (!_disposedValue)
+                    {
+                        if (disposing)
+                        {
+                            BaseDisposableObject?.Dispose();
+                        }
 
-                if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, false))
-                {
-                    throw new ObjectDisposedException("SetConsoleCtrlHandler failed to remove handler.");
-                }
+                        if (!Kernel32.SetConsoleCtrlHandler(_HandlerRoutine, false))
+                        {
+                            throw new ObjectDisposedException("SetConsoleCtrlHandler failed to remove handler.");
+                        }
 
-                _disposedValue = true;
+                        _disposedValue = true;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
# The Problem:
When the running harness was stopped with a console control signal such as: Ctrl-C, Ctrl-Break, or Close signals, the trace event session did not clean up properly, the handles to the etl files and sessions themselves persisted.

# The Solution:
Wraps the trace event sessions in an object that subscribe them to a Ctrl listener, and dispose them accordingly when the signal is received.

## Note:
Killing the process under the debugger, with the signals specified above, does not make it very happy. The process seems continue running or crashes.