### PR TITLE
New metrics parsing + bug fixes

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=alpha-build0048
+  set VersionSuffix=alpha-build0049
   set PackageVersion=1.0.0-%VersionSuffix%
 
   REM Check that git is on path.

--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Xunit.Performance.Api
         /// <returns></returns>
         public static void Record(string assemblyFileName, string runId, string outputDirectory, Action action, Action<string> collectOutputFilesCallback)
         {
-            const int bufferSizeMB = 128;
+            const int bufferSizeMB = 256;
             var sessionName = $"Performance-Api-Session-{runId}";
             var name = $"{runId}-{Path.GetFileNameWithoutExtension(assemblyFileName)}";
             var userFullFileName = Path.Combine(outputDirectory, $"{name}.etl");

--- a/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
+++ b/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
@@ -31,9 +31,7 @@ namespace Microsoft.Xunit.Performance.Api
             benchmarkParser.BenchmarkIterationStart += delegate (BenchmarkIterationStartArgs args)
             {
                 if (args.RunId != _runid)
-                {
                     return;
-                }
 
                 if (_currentTestCase != null)
                     throw new InvalidOperationException(args.TimeStampRelativeMSec.ToString());

--- a/src/xunit.performance.api/PerformanceMonitorCounter/BasePerformanceMonitorCounter.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/BasePerformanceMonitorCounter.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using Microsoft.Xunit.Performance.Sdk;
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal abstract class BasePerformanceMonitorCounter : PerformanceMetric
+    {
+        public BasePerformanceMonitorCounter(IPerformanceMonitorCounter pmc) : base(pmc.Name, pmc.DisplayName, pmc.Unit)
+        {
+            _interval = pmc.Interval;
+            if (TraceEventProfileSources.GetInfo().TryGetValue(Id, out ProfileSourceInfo profileSourceInfo))
+                _profileSourceInfoID = profileSourceInfo.ID;
+            else
+                _profileSourceInfoID = -1;
+        }
+
+        public override IEnumerable<ProviderInfo> ProviderInfo
+        {
+            get
+            {
+                yield return new KernelProviderInfo()
+                {
+                    Keywords = unchecked((ulong)(KernelTraceEventParser.Keywords.PMCProfile | KernelTraceEventParser.Keywords.Profile)),
+                };
+                yield return new CpuCounterInfo()
+                {
+                    CounterName = Id,
+                    Interval = _interval,
+                };
+            }
+        }
+
+        public bool IsValidPmc => _profileSourceInfoID > -1;
+
+        protected int ProfileSourceInfoID => _profileSourceInfoID;
+
+        private readonly int _interval;
+        private readonly int _profileSourceInfoID;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/BranchMispredictionsPerformanceMonitorCounter.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/BranchMispredictionsPerformanceMonitorCounter.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class BranchMispredictionsPerformanceMonitorCounter : IPerformanceMonitorCounter
+    {
+        public string DisplayName => "Branch Mispredictions";
+
+        public string Name => "BranchMispredictions";
+
+        public string Unit => "count";
+
+        public int Interval => 1000;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/CacheMissesPerformanceMonitorCounter.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/CacheMissesPerformanceMonitorCounter.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class CacheMissesPerformanceMonitorCounter : IPerformanceMonitorCounter
+    {
+        public string DisplayName => "Cache Misses";
+
+        public string Name => "CacheMisses";
+
+        public string Unit => "count";
+
+        public int Interval => 1000;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterDiscoverer.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterDiscoverer.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Diagnostics.Tracing.Session;
+using Microsoft.Xunit.Performance.Sdk;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class GenericPerformanceMonitorCounterDiscoverer<T> : IPerformanceMetricDiscoverer
+        where T : IPerformanceMonitorCounter, new()
+    {
+        public GenericPerformanceMonitorCounterDiscoverer()
+        {
+            _performanceMonitorCounter = new T();
+            if (TraceEventProfileSources.GetInfo().TryGetValue(_performanceMonitorCounter.Name, out ProfileSourceInfo profileSourceInfo))
+                _pmcId = profileSourceInfo.ID;
+            else
+                _pmcId = -1;
+        }
+
+        public IEnumerable<PerformanceMetricInfo> GetMetrics(IAttributeInfo metricAttribute)
+        {
+            if (_pmcId != -1)
+            {
+                var interval = (int)(metricAttribute.GetConstructorArguments().FirstOrDefault() ?? _performanceMonitorCounter.Interval);
+                yield return new GenericPerformanceMonitorCounterMetric<T>(_performanceMonitorCounter);
+            }
+        }
+
+        private readonly int _pmcId;
+        private readonly T _performanceMonitorCounter;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterEvaluator.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterEvaluator.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Xunit.Performance.Sdk;
+using System.Diagnostics;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal class GenericPerformanceMonitorCounterEvaluator<T> : PerformanceMetricEvaluator
+        where T : IPerformanceMonitorCounter, new()
+    {
+        private PerformanceMetricEvaluationContext _context;
+        private int _profileSource;
+        private int _interval;
+        private long _count;
+
+        internal void Initialize(PerformanceMetricEvaluationContext context, int profileSourceInfoID)
+        {
+            lock (this)
+            {
+                if (_context == null)
+                {
+                    context.TraceEventSource.Kernel.PerfInfoCollectionStart += PerfInfoCollectionStart;
+                    context.TraceEventSource.Kernel.PerfInfoPMCSample += PerfInfoPMCSample;
+                    _context = context;
+                    _profileSource = profileSourceInfoID;
+                }
+                else
+                {
+                    Debug.Assert(_context == context);
+                    Debug.Assert(_profileSource == profileSourceInfoID);
+                }
+            }
+        }
+
+        private void PerfInfoCollectionStart(SampledProfileIntervalTraceData ev)
+        {
+            if (ev.SampleSource == _profileSource)
+                _interval = ev.NewInterval;
+        }
+
+        private void PerfInfoPMCSample(PMCCounterProfTraceData ev)
+        {
+            if (ev.ProfileSource == _profileSource && _context.IsTestEvent(ev))
+                _count += _interval;
+        }
+
+        public override void BeginIteration(TraceEvent beginEvent)
+        {
+            _count = 0;
+        }
+
+        public override double EndIteration(TraceEvent endEvent)
+        {
+            return _count;
+        }
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterMetric.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/GenericPerformanceMonitorCounterMetric.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Xunit.Performance.Sdk;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class GenericPerformanceMonitorCounterMetric<T> : BasePerformanceMonitorCounter
+        where T : IPerformanceMonitorCounter, new()
+    {
+        static GenericPerformanceMonitorCounterMetric()
+        {
+            s_evaluators = new ConditionalWeakTable<PerformanceMetricEvaluationContext, GenericPerformanceMonitorCounterEvaluator<T>>();
+        }
+
+        public GenericPerformanceMonitorCounterMetric(T pmc) : base(pmc)
+        {
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            var evaluator = s_evaluators.GetOrCreateValue(context);
+            evaluator.Initialize(context, ProfileSourceInfoID);
+            return evaluator;
+        }
+
+        //
+        // We create just one PerformanceMetricEvaluator per PerformanceEvaluationContext (which represents a single ETW session).
+        // This lets us track state (the counter sampling interval) across test cases.  It would be nice if PerformanceMetricEvaluationContext
+        // made this easier, but for now we'll just track the relationship with a ConditionalWeakTable.
+        //
+        // TODO: consider better support for persistent state in PerformanceMetricEvaluationContext.
+        //
+        private static readonly ConditionalWeakTable<PerformanceMetricEvaluationContext, GenericPerformanceMonitorCounterEvaluator<T>> s_evaluators;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMonitorCounter/IPerformanceMonitorCounter.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/IPerformanceMonitorCounter.cs
@@ -1,0 +1,13 @@
+﻿namespace Microsoft.Xunit.Performance.Api
+{
+    interface IPerformanceMonitorCounter
+    {
+        string DisplayName { get; }
+
+        string Name { get; }
+
+        string Unit { get; }
+
+        int Interval { get; }
+    }
+}

--- a/src/xunit.performance.api/XunitRunner.cs
+++ b/src/xunit.performance.api/XunitRunner.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Xunit.Abstractions;
 using Xunit.Runners;
 using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
 
@@ -63,11 +64,13 @@ namespace Microsoft.Xunit.Performance.Api
 
         private static void SetupRunnerCallbacks(AssemblyRunner runner, ManualResetEvent manualResetEvent, object consoleLock, int[] result)
         {
+            runner.TestCaseFilter = (ITestCase testCase) => testCase.GetType() == typeof(BenchmarkTestCase);
+
             runner.OnDiscoveryComplete = info =>
             {
                 lock (consoleLock)
                 {
-                    WriteInfoLine($"Running {info.TestCasesToRun} of {info.TestCasesDiscovered} tests...");
+                    WriteInfoLine($"Running {info.TestCasesToRun} Benchmarks out of {info.TestCasesDiscovered} Xunit Facts...");
                 }
             };
             runner.OnExecutionComplete = info =>

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -1,7 +1,10 @@
 using Microsoft.Xunit.Performance;
 using Microsoft.Xunit.Performance.Api;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 [assembly: MeasureGCAllocations]
@@ -24,25 +27,29 @@ namespace simpleharness
         {
             var args = new string[] { "FFT", "LU", "MC", "MM", "SOR", "\u03C3", "x\u0305" };
             foreach (var arg in args)
-            {
                 yield return new object[] { new string[] { arg } };
-            }
         }
 
-        [Benchmark(InnerIterationCount = 10000)]
+        [Benchmark(InnerIterationCount = 10)]
         [MemberData(nameof(InputData))]
-        public static void TestBenchmark(string[] args)
+        private static void TestMultipleStringInputs(string[] args)
         {
-            foreach (BenchmarkIteration iter in Benchmark.Iterations)
-            {
-                using (iter.StartMeasurement())
-                {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                    {
-                        string.Format("{0}{1}{2}{3}", args[0], args[0], args[0], args[0]);
-                    }
-                }
-            }
+           foreach (BenchmarkIteration iter in Benchmark.Iterations)
+           {
+               using (iter.StartMeasurement())
+               {
+                   for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                   {
+                       FormattedString(args[0], args[0], args[0], args[0]);
+                   }
+               }
+           }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static string FormattedString(string a, string b, string c, string d)
+        {
+            return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
 
         public sealed class Type_1
@@ -61,12 +68,9 @@ namespace simpleharness
                     }
                 }
             }
-        }
 
-        public sealed class Type_2
-        {
-            [Benchmark(InnerIterationCount = 10000)]
-            public void TestBenchmark1()
+            [Fact]
+            public void TestFact()
             {
                 foreach (BenchmarkIteration iter in Benchmark.Iterations)
                 {
@@ -79,20 +83,75 @@ namespace simpleharness
                     }
                 }
             }
+        }
 
-            [Benchmark(InnerIterationCount = 10000)]
-            public void TestBenchmark2()
+        public sealed class Type_2
+        {
+            [Benchmark(InnerIterationCount = 1)]
+            public static void RandomAccess()
             {
                 foreach (BenchmarkIteration iter in Benchmark.Iterations)
                 {
                     using (iter.StartMeasurement())
                     {
-                        for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        for (int i = 0; i < Benchmark.InnerIterationCount; ++i)
                         {
-                            string.Format("{0}{1}{2}{3}", "a", "b", "c", "d");
+                            MemoryAccessPerformance();
                         }
                     }
                 }
+            }
+
+            [Benchmark(InnerIterationCount = 10000)]
+            public static void ShufflingDeckOfCard()
+            {
+                foreach (BenchmarkIteration iter in Benchmark.Iterations)
+                {
+                    using (iter.StartMeasurement())
+                    {
+                        for (int i = 0; i < Benchmark.InnerIterationCount; ++i)
+                        {
+                            BranchPredictionPerformance(i);
+                        }
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static double MemoryAccessPerformance()
+            {
+                var doubles = new double[8 * 1024 * 1024];
+                for (int i = 0; i < doubles.Length; i += 100)
+                    doubles[i] = 2.0;
+                for (int i = 0; i < doubles.Length; i += 200)
+                    doubles[i] *= 3.0;
+                for (int i = 0; i < doubles.Length; i += 400)
+                    doubles[i] *= 5.0;
+                for (int i = 0; i < doubles.Length; i += 800)
+                    doubles[i] *= 7.0;
+                for (int i = 0; i < doubles.Length; i += 1600)
+                    doubles[i] *= 11.0;
+                return doubles.Average();
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static IEnumerable<int> BranchPredictionPerformance(int seed)
+            {
+                const int nCards = 52;
+                var deck = new List<int>(Enumerable.Range(0, nCards));
+                var rnd = new Random((int)DateTime.Now.Ticks + seed);
+
+                for (int i = 0; i < deck.Count(); ++i)
+                {
+                    var pos = rnd.Next(nCards);
+                    if (pos % 3 != 0)
+                        pos = rnd.Next(nCards);
+                    var temp = deck[i];
+                    deck[i] = deck[pos];
+                    deck[pos] = temp;
+                }
+
+                return deck;
             }
         }
     }


### PR DESCRIPTION
1. Doubled the trace event session's object buffer size
2. Parse Pmc default collected data (Branch misspredictions + Cache misses)
3. Fix a bug on the xunit runner that was not filtering on Benchmark and was running all Xunit Facts.
