### PR TITLE
Remove CSwitch from the default collection

### DIFF
--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Xunit.Performance.Api
                     userEventSession.BufferSizeMB = bufferSizeMB;
 
                     var flags = KernelTraceEventParser.Keywords.Process | KernelTraceEventParser.Keywords.ImageLoad | KernelTraceEventParser.Keywords.Thread;
-                    var stackCapture = KernelTraceEventParser.Keywords.Profile | KernelTraceEventParser.Keywords.ContextSwitch;
+                    var stackCapture = KernelTraceEventParser.Keywords.Profile;
                     userEventSession.EnableKernelProvider(flags, stackCapture);
 
                     foreach (var userProviderInfo in providers.OfType<UserProviderInfo>())


### PR DESCRIPTION
By default we were collecting context switch events and not using them
during analysis.  This removes this because it greatly inflates the size
of the collected ETL file and was causing us to drop events and fail on
certain test.