### PR TITLE
Adding allocations for current thread, bug fixes, and stop building old runner.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,27 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": ".NET Core 1.0",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/tools/bin/dotnet.exe",
-            "args": ["${workspaceRoot}/tests/simpleharness/bin/Debug/netcoreapp1.1/simpleharness.dll"],
+            "preLaunchTask": "build-debug",
+            "program": "${workspaceRoot}/tools/dotnet/1.0.0/dotnet.exe",
+            "args": [
+                "${workspaceRoot}/tests/simpleharness/bin/Debug/netcoreapp1.0/simpleharness.dll"
+            ],
+            "cwd": "${workspaceRoot}/tests/simpleharness",
+            "stopAtEntry": false,
+            "externalConsole": false
+        },
+        {
+            "name": ".NET Core 1.1",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-debug",
+            "program": "${workspaceRoot}/tools/dotnet/1.0.0/dotnet.exe",
+            "args": [
+                "${workspaceRoot}/tests/simpleharness/bin/Debug/netcoreapp1.1/simpleharness.dll"
+            ],
             "cwd": "${workspaceRoot}/tests/simpleharness",
             "stopAtEntry": false,
             "externalConsole": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             "program": "${workspaceRoot}/tools/bin/dotnet.exe",
-            "args": ["${workspaceRoot}/tests/simpleharness/bin/Debug/netcoreapp1.0/simpleharness.dll"],
+            "args": ["${workspaceRoot}/tests/simpleharness/bin/Debug/netcoreapp1.1/simpleharness.dll"],
             "cwd": "${workspaceRoot}/tests/simpleharness",
             "stopAtEntry": false,
             "externalConsole": false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,16 +2,34 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "0.1.0",
-    "command": "${workspaceRoot}/tools/bin/dotnet.exe",
+    "command": "${workspaceRoot}/tools/dotnet/1.0.0/dotnet.exe",
     "isShellCommand": true,
-    "args": [],
+    "args": [
+        "build",
+        "${workspaceRoot}/tests/simpleharness/simpleharness.csproj"
+    ],
     "tasks": [
         {
-            "taskName": "build",
-            "args": [ "${workspaceRoot}/tests/simpleharness/simpleharness.csproj" ],
+            "taskName": "build-debug",
+            "args": [
+                "-c",
+                "debug"
+            ],
             "isBuildCommand": true,
             "showOutput": "always",
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "suppressTaskName": true
+        },
+        {
+            "taskName": "build-release",
+            "args": [
+                "-c",
+                "release"
+            ],
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "problemMatcher": "$msCompile",
+            "suppressTaskName": true
         }
     ]
 }

--- a/BuildCliComponents.sh
+++ b/BuildCliComponents.sh
@@ -14,12 +14,12 @@
 # set -x
 
 declare currentDir=`pwd`
+declare dotnetVersion=`cat DotNetCliVersion.txt`
 declare outputDirectory=${currentDir}/LocalPackages
-declare dotnetPath=${currentDir}/tools/bin/ubuntu
+declare dotnetPath=${currentDir}/tools/dotnet/${dotnetVersion}
 declare dotnetCmd=${dotnetPath}/dotnet
 declare dotnetInstallerUrl=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
 declare dotnetInstallerScript=${dotnetPath}/dotnet-install.sh
-declare dotnetVersion=`cat DotNetCliVersion.txt`
 
 if ! [ -f $dotnetCmd ]
 then
@@ -50,17 +50,9 @@ fi
 declare versionSuffix=$2
 if [ "$versionSuffix" == "" ]
 then
-	versionSuffix="build0000"
+	versionSuffix="beta-build0000"
 fi
 
-$dotnetCmd restore
-pushd ${currentDir}/src/cli/Microsoft.DotNet.xunit.performance.runner.cli > /dev/null
-$dotnetCmd build -c $buildConfiguration --version-suffix $versionSuffix
-$dotnetCmd pack -c $buildConfiguration -o $outputDirectory --version-suffix $versionSuffix
-popd > /dev/null
-pushd ${currentDir}/src/cli/Microsoft.DotNet.xunit.performance.analysis.cli > /dev/null
-$dotnetCmd build -c $buildConfiguration --version-suffix $versionSuffix
-$dotnetCmd pack -c $buildConfiguration -o $outputDirectory --version-suffix $versionSuffix
-popd > /dev/null
+# TODO: Update groovy file and this file.
 
 echo Build complete

--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -6,7 +6,6 @@ setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
   set VersionSuffix=beta-build0001
-  set PackageVersion=1.0.0-%VersionSuffix%
 
   REM Check that git is on path.
   where.exe /Q git.exe || (
@@ -30,7 +29,7 @@ setlocal EnableDelayedExpansion
   )
 
   echo/==================
-  echo/ Building version %PackageVersion% NuGet packages.
+  echo/ Building version %VersionSuffix% NuGet packages.
   echo/==================
-  call build.cmd %BuildConfiguration% %VersionSuffix% %PackageVersion%
+  call build.cmd %BuildConfiguration% %VersionSuffix%
 endlocal& exit /b %errorlevel%

--- a/README.md
+++ b/README.md
@@ -20,21 +20,17 @@ Each [Benchmark]-annotated test must contain a loop of this form:
 [Benchmark]
 void TestMethod()
 {
-  // Any per-test-case setup can go here.
-
-  foreach (var iteration in Benchmark.Iterations)
-  {
-    // Any per-iteration setup can go here.
-
-    using (iteration.StartMeasurement())
+    // Any per-test-case setup can go here.
+    foreach (var iteration in Benchmark.Iterations)
     {
-      // Code to be measured goes here.
+        // Any per-iteration setup can go here.
+        using (iteration.StartMeasurement())
+        {
+            // Code to be measured goes here.
+        }
+        // ...per-iteration cleanup
     }
-
-    // ...per-iteration cleanup
-  }
-
-  // ...per-test-case cleanup
+    // ...per-test-case cleanup
 }
 ```
 
@@ -44,9 +40,9 @@ The simplest possible benchmark is therefore:
 [Benchmark]
 void EmptyBenchmark()
 {
-  foreach (var iteration in Benchmark.Iterations)
-    using (iteration.StartMeasurement())
-      ; //do nothing
+    foreach (var iteration in Benchmark.Iterations)
+        using (iteration.StartMeasurement())
+            ; //do nothing
 }
 ```
 
@@ -56,7 +52,7 @@ This may also be written as:
 [Benchmark]
 void EmptyBenchmark()
 {
-  Benchmark.Iterate(() => { /*do nothing*/ });
+    Benchmark.Iterate(() => { /*do nothing*/ });
 }
 ```
 
@@ -69,24 +65,68 @@ For very small benchmarks that complete very quickly (microseconds), it is recom
 [Benchmark(InnerIterationCount=500)]
 void TestMethod()
 {
-  foreach (var iteration in Benchmark.Iterations)
-    using (iteration.StartMeasurement())
-      for(int i=0; i<Benchmark.InnerIterationCount; i++)
-        // test code here
+    foreach (var iteration in Benchmark.Iterations)
+        using (iteration.StartMeasurement())
+            for(int i=0; i<Benchmark.InnerIterationCount; i++)
+                // test code here
 }
 ```
 
-The first iteration is the "warmup" iteration; all performance metrics are discarded by the result analyzer.  Subsequent iterations are measured.
+The first iteration is the "warmup" iteration; all performance metrics are discarded by the result analyzer. Subsequent iterations are measured.
+
+## Creating a simple harness to execute the API
+
+The following sample code shows how a small piece of code can iterate through a list of .NET assemblies to run benchmarks.
+
+```csharp
+using System.IO;
+using System.Reflection;
+using Microsoft.Xunit.Performance.Api;
+
+namespace SampleApiTest
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            using (var harness = new XunitPerformanceHarness(args))
+            {
+                foreach(var testName in GetTestNames())
+                {
+                    // Here, the example assumes that the list of .NET
+                    // assemblies are dropped side-by-side with harness
+                    // (the current executing assembly)
+                    var currentDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                    var assemblyPath = Path.Combine(currentDirectory, $"{testName}.dll");
+
+                    // Execute the benchmarks, if any, in this assembly.
+                    harness.RunBenchmarks(assemblyPath);
+                }
+            }
+        }
+
+        private static string[] GetTestNames()
+        {
+            return new [] {
+                "Benchmarks",
+                "System.Binary.Base64.Tests",
+                "System.Text.Primitives.Performance.Tests",
+                "System.Slices.Tests"
+            };
+        }
+    }
+}
+```
 
 ## Running benchmarks
 
-The normal xUnit runners will run Benchmarks as normal unit tests.  The test execution times reported in the normal xUnit test results are for a single iteration, and so do not tell you much about the methods' performance.
+The normal xUnit runners will run Benchmarks as normal unit tests. The test execution times reported in the normal xUnit test results are for a single iteration, and so do not tell you much about the methods' performance.
 
 To collect more detailed data, use xunit.performance.run.exe:
 
 > xunit.performance.run MyTests.dll -runner xunit.console.exe -runid MyRun1234
 
-This will produce files named MyRun1234.etl and MyRun1234.xml in the current directory.  MyRun1234.xml contains the detailed test results (including all performance metrics).
+This will produce files named MyRun1234.etl and MyRun1234.xml in the current directory. MyRun1234.xml contains the detailed test results (including all performance metrics).
 
 ## Analyzing test results
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ Provides extensions over xUnit to author performance tests.
 
 1. Create a new class library project
 2. Add a reference to the "xUnit" NuGet package
-3. Add a reference to xunit.performance.core.dll
+3. Add a reference to the latest [xunit.performance.api.dll](https://dotnet.myget.org/feed/dotnet-core/package/nuget/xunit.performance.api)
 4. Tag your test methods with [Benchmark] instead of [Fact]
-
-Each [Benchmark]-annotated test must contain a loop of this form:
+5. Make sure that each [Benchmark]-annotated test contains a loop of this form:
 
 ```csharp
 [Benchmark]
@@ -46,7 +45,7 @@ void EmptyBenchmark()
 }
 ```
 
-This may also be written as:
+Which can also be written as:
 
 ```csharp
 [Benchmark]
@@ -56,7 +55,7 @@ void EmptyBenchmark()
 }
 ```
 
-For very small benchmarks that complete very quickly (microseconds), it is recommend to add an inner loop to ensure that test code runs long enough to dominate the harness overhead:
+In addition, you can add inner iterations to the code to be measured.
 
 1. Add the for loop using Benchmark.InnerIterationCount as the number of loop iterations
 2. Specify the value of InnerIterationCount using the [Benchmark] attribute
@@ -65,18 +64,98 @@ For very small benchmarks that complete very quickly (microseconds), it is recom
 [Benchmark(InnerIterationCount=500)]
 void TestMethod()
 {
+    // The first iteration is the "warmup" iteration, where all performance
+    // metrics are discarded. Subsequent iterations are measured.
     foreach (var iteration in Benchmark.Iterations)
         using (iteration.StartMeasurement())
-            for(int i=0; i<Benchmark.InnerIterationCount; i++)
+            // Inner iterations are recommended for fast running benchmarks
+            // that complete very quickly (microseconds). This ensures that
+            // the benchmark code runs long enough to dominate the harness's
+            // overhead.
+            for (int i=0; i<Benchmark.InnerIterationCount; i++)
                 // test code here
 }
 ```
 
-The first iteration is the "warmup" iteration; all performance metrics are discarded by the result analyzer. Subsequent iterations are measured.
+If you need to execute different permutation of the same benchmark, then you can use this approach:
+
+```csharp
+public static IEnumerable<object[]> InputData()
+{
+    var args = new string[] { "foo", "bar", "baz" };
+    foreach (var arg in args)
+        // Currently, the only limitation of this approach is that the
+        // types passed to the [Benchmark]-annotated test must be serializable.
+        yield return new object[] { new string[] { arg } };
+}
+
+// NoInlining prevents aggressive optimizations that
+// could render the benchmark meaningless
+[MethodImpl(MethodImplOptions.NoInlining)]
+private static string FormattedString(string a, string b, string c, string d)
+{
+    return string.Format("{0}{1}{2}{3}", a, b, c, d);
+}
+
+// This benchmark will be executed 3 different times,
+// with { "foo" }, { "bar" }, and { "baz" } as args.
+[MeasureGCCounts]
+[Benchmark(InnerIterationCount = 10)]
+[MemberData(nameof(InputData))]
+public static void TestMultipleStringInputs(string[] args)
+{
+    foreach (BenchmarkIteration iter in Benchmark.Iterations)
+    {
+        using (iter.StartMeasurement())
+        {
+            for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+            {
+                FormattedString(args[0], args[0], args[0], args[0]);
+            }
+        }
+    }
+}
+```
 
 ## Creating a simple harness to execute the API
 
-The following sample code shows how a small piece of code can iterate through a list of .NET assemblies to run benchmarks.
+### Option #1: Creating a self containing harness + benchmark
+
+```csharp
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
+using System.Reflection;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        using (XunitPerformanceHarness p = new XunitPerformanceHarness(args))
+        {
+            string entryAssemblyPath = Assembly.GetEntryAssembly().Location;
+            p.RunBenchmarks(entryAssemblyPath);
+        }
+    }
+
+    [Benchmark(InnerIterationCount=10000)]
+    public void TestBenchmark()
+    {
+        foreach(BenchmarkIteration iter in Benchmark.Iterations)
+        {
+            using(iter.StartMeasurement())
+            {
+                for(int i=0; i<Benchmark.InnerIterationCount; i++)
+                {
+                    string.Format("{0}{1}{2}{3}", "a", "b", "c", "d");
+                }
+            }
+        }
+    }
+}
+
+```
+
+### Option #2: Creating a harness that iterates through a list of .NET assemblies containing the benchmarks.
 
 ```csharp
 using System.IO;
@@ -118,19 +197,29 @@ namespace SampleApiTest
 }
 ```
 
-## Running benchmarks
+## Supported metrics
 
-The normal xUnit runners will run Benchmarks as normal unit tests. The test execution times reported in the normal xUnit test results are for a single iteration, and so do not tell you much about the methods' performance.
+Currently, the API collect the following data **:
 
-To collect more detailed data, use xunit.performance.run.exe:
+Metric                                | Type                                     | Description
+------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------
+**Allocated Bytes in Current Thread** | GC API call                              | Calls `GC.GetAllocatedBytesForCurrentThread` around the benchmark (Enabled if available on the target .NET runtime)
+**Branch Mispredictions**             | Performance Monitor Counter              | Enabled if the counter is available on the machine
+**Cache Misses**                      | Performance Monitor Counter              | Enabled if the counter is available on the machine
+**Duration**                          | Benchmark execution time in milliseconds | Always enabled
+**GC Allocations**                    | GC trace event                           | Use the `[MeasureGCAllocations]` attribute in the source code
+**GC Count**                          | GC trace event                           | Use the `[MeasureGCCounts]` attribute in the source code
+**Instructions Retired**              | Performance Monitor Counter              | Use the `[MeasureInstructionsRetired]` attribute in the source code
 
-> xunit.performance.run MyTests.dll -runner xunit.console.exe -runid MyRun1234
+**The default metrics are subject to change, and we are currently working on enabling more metrics and adding support to have more control around the metrics being captured.
 
-This will produce files named MyRun1234.etl and MyRun1234.xml in the current directory. MyRun1234.xml contains the detailed test results (including all performance metrics).
+## Collected data
 
-## Analyzing test results
+Currently the API generates different output files with the collected data:
 
-Use xunit.performance.analysis.exe:
-
-> xunit.performance.analysis MyRun1234
-
+Format | Data
+:----: | ----
+  csv  | File contaning statistics of the collected metrics
+  etl  | Trace file (Windows only)
+  md   | Markdown file with statistics rendered as a table (github friendly)
+  xml  | Serialized raw data of all of the tests with their respective metrics

--- a/build.cmd
+++ b/build.cmd
@@ -10,9 +10,6 @@ setlocal enabledelayedexpansion
   set VersionSuffix=%~2
   if "%VersionSuffix%"=="" set VersionSuffix=beta-build0000
 
-  set PackageVersion=%~3
-  if "%PackageVersion%"=="" set PackageVersion=1.0.0-%VersionSuffix%
-
   set OutputDirectory=%~dp0LocalPackages
   call :remove_directory "%OutputDirectory%" || exit /b 1
 

--- a/build.cmd
+++ b/build.cmd
@@ -4,13 +4,6 @@
 :main
 setlocal enabledelayedexpansion
   set errorlevel=
-
-  set lv_api_only=
-  if /I "%~1" == "--api-only" (
-    set lv_api_only=1
-    shift
-  )
-
   set BuildConfiguration=%~1
   if "%BuildConfiguration%"=="" set BuildConfiguration=Debug
 
@@ -26,26 +19,9 @@ setlocal enabledelayedexpansion
   call "%~dp0.\dotnet-install.cmd" || exit /b 1
 
   set procedures=
-
-  if not defined lv_api_only (
-    set procedures=!procedures! build_procdomain
-    set procedures=!procedures! build_xunit_performance_analysis
-    set procedures=!procedures! build_xunit_performance_core
-    set procedures=!procedures! build_xunit_performance_execution
-    set procedures=!procedures! build_xunit_performance_metrics
-    set procedures=!procedures! build_xunit_performance_logger
-    set procedures=!procedures! build_xunit_performance_run
-    set procedures=!procedures! build_microsoft_dotnet_xunit_performance_runner_cli
-    set procedures=!procedures! build_microsoft_dotnet_xunit_performance_analysis_cli
-    set procedures=!procedures! build_samples_classlibrary_net46
-    set procedures=!procedures! build_samples_simpleperftests
-    REM set procedures=!procedures! nuget_pack_src
-  ) else (
-    set procedures=!procedures! build_xunit_performance_core
-    set procedures=!procedures! build_xunit_performance_execution
-    set procedures=!procedures! build_xunit_performance_metrics
-  )
-
+  set procedures=%procedures% build_xunit_performance_core
+  set procedures=%procedures% build_xunit_performance_execution
+  set procedures=%procedures% build_xunit_performance_metrics
   set procedures=%procedures% build_xunit_performance_api
   set procedures=%procedures% build_tests_simpleharness
 
@@ -55,19 +31,7 @@ setlocal enabledelayedexpansion
       exit /b 1
     )
   )
-  exit /b %errorlevel%
-
-:build_procdomain
-setlocal
-  cd /d %~dp0src\procdomain
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:build_xunit_performance_analysis
-setlocal
-  cd /d %~dp0src\xunit.performance.analysis
-  call :dotnet_build
-  exit /b %errorlevel%
+endlocal& exit /b %errorlevel%
 
 :build_xunit_performance_core
 setlocal
@@ -81,57 +45,11 @@ setlocal
   call :dotnet_pack
   exit /b %errorlevel%
 
-:build_xunit_performance_logger
-setlocal
-  cd /d %~dp0src\xunit.performance.logger
-  call :dotnet_build
-  exit /b %errorlevel%
-
 :build_xunit_performance_metrics
 setlocal
   cd /d %~dp0src\xunit.performance.metrics
   call :dotnet_pack
   exit /b %errorlevel%
-
-:build_xunit_performance_run
-setlocal
-  cd /d %~dp0src\xunit.performance.run
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:build_microsoft_dotnet_xunit_performance_runner_cli
-setlocal
-  cd /d %~dp0src\cli\Microsoft.DotNet.xunit.performance.runner.cli
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:build_microsoft_dotnet_xunit_performance_analysis_cli
-setlocal
-  cd /d %~dp0src\cli\Microsoft.DotNet.xunit.performance.analysis.cli
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:build_samples_classlibrary_net46
-setlocal
-  cd /d %~dp0samples\ClassLibrary.net46
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:build_samples_simpleperftests
-setlocal
-  cd /d %~dp0samples\SimplePerfTests
-  call :dotnet_build
-  exit /b %errorlevel%
-
-:nuget_pack_src
-setlocal
-  cd /d %~dp0src
-  dotnet.exe restore xunit.performance.csproj                                                                                                                           || exit /b 1
-  dotnet.exe pack xunit.performance.csproj                 --no-build -c %BuildConfiguration% -o "%OutputDirectory%" --version-suffix %VersionSuffix% --include-symbols || exit /b 1
-
-  dotnet.exe restore xunit.performance.runner.Windows.csproj                                                                                                            || exit /b 1
-  dotnet.exe pack xunit.performance.runner.Windows.csproj  --no-build -c %BuildConfiguration% -o "%OutputDirectory%" --version-suffix %VersionSuffix% --include-symbols || exit /b 1
-  exit /b 0
 
 :build_xunit_performance_api
 setlocal

--- a/build.cmd
+++ b/build.cmd
@@ -8,7 +8,7 @@ setlocal enabledelayedexpansion
   if "%BuildConfiguration%"=="" set BuildConfiguration=Debug
 
   set VersionSuffix=%~2
-  if "%VersionSuffix%"=="" set VersionSuffix=alpha-build0000
+  if "%VersionSuffix%"=="" set VersionSuffix=beta-build0000
 
   set PackageVersion=%~3
   if "%PackageVersion%"=="" set PackageVersion=1.0.0-%VersionSuffix%
@@ -65,7 +65,13 @@ setlocal
     call :print_error_message Cannot run simpleharness test because this is not an administrator window
     exit /b 1
   )
-  dotnet.exe run -c %BuildConfiguration% "bin\%BuildConfiguration%\netcoreapp1.0\simpleharness.dll" || exit /b 1
+
+  dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp1.0  || exit /b 1
+  dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp1.1  || exit /b 1
+
+  rem Use this as a prefix for dotnet.exe in order to launch the process on a different window: START "TITLE GOES HERE" /WAIT
+  dotnet.exe "bin\%BuildConfiguration%\netcoreapp1.0\simpleharness.dll" || exit /b 1
+  dotnet.exe "bin\%BuildConfiguration%\netcoreapp1.1\simpleharness.dll" || exit /b 1
   exit /b %errorlevel%
 
 :dotnet_build

--- a/buildapi.cmd
+++ b/buildapi.cmd
@@ -1,8 +1,0 @@
-@echo off
-goto :main
-
-:main
-setlocal
-  set errorlevel=
-  call "%~dp0.\build.cmd" --api-only %*
-endlocal& exit /b %errorlevel%

--- a/dotnet-install.cmd
+++ b/dotnet-install.cmd
@@ -3,10 +3,15 @@
 
 :install_dotnet_cli
 setlocal
-  set DotNet=%~dp0\tools\bin\dotnet.exe
-  set DotNet_Path=%~dp0tools\bin
-  set Init_Tools_Log=%DotNet_Path%\install.log
   set /p DotNet_Version=<"%~dp0DotNetCLIVersion.txt"
+  if not defined DotNet_Version (
+    call :print_error_message Unknown DotNet CLI Version.
+    exit /b 1
+  )
+
+  set DotNet_Path=%~dp0tools\dotnet\%DotNet_Version%
+  set DotNet=%DotNet_Path%\dotnet.exe
+  set Init_Tools_Log=%DotNet_Path%\install.log
   set DotNet_Installer_Url=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1
 
   REM dotnet.exe might exist, but it might not be the right version.

--- a/src/xunit.performance.api/Common.cs
+++ b/src/xunit.performance.api/Common.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.InteropServices;
+using System.Security.Principal;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    /// <summary>
+    /// This class provides common utilities to the API.
+    /// </summary>
+    internal static class Common
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <remarks>
+        /// TODO: Revisit checking if admin for non-Windows platform.
+        /// </remarks>
+        public static bool IsRunningAsAdministrator
+        {
+            get
+            {
+                using (var identity = WindowsIdentity.GetCurrent())
+                {
+                    var principal = new WindowsPrincipal(identity);
+                    return principal.IsInRole(WindowsBuiltInRole.Administrator);
+                }
+            }
+        }
+
+        public static bool IsWindowsPlatform => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+    }
+}

--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -6,10 +6,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using static Microsoft.Xunit.Performance.Api.Common;
 using static Microsoft.Xunit.Performance.Api.Native.Windows.Kernel32;
-using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
+using static Microsoft.Xunit.Performance.Api.PerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -242,22 +241,24 @@ namespace Microsoft.Xunit.Performance.Api
         private static void PrintAvailableProfileSources()
         {
             var availableProfileSources = TraceEventProfileSources.GetInfo();
-            var cpuCounterIds = new List<int>();
-            var cpuCounterIntervals = new List<int>();
-            var sb = new StringBuilder();
 
             foreach (var kvp in availableProfileSources)
             {
-                sb.AppendLine();
-                sb.AppendLine($"Profile name: {kvp.Key}");
-                sb.AppendLine($"  ID :          {kvp.Value.ID}");
-                sb.AppendLine($"  Interval :    {kvp.Value.Interval}");
-                sb.AppendLine($"  MaxInterval : {kvp.Value.MaxInterval}");
-                sb.AppendLine($"  MinInterval : {kvp.Value.MinInterval}");
-                sb.AppendLine();
+                Debug.WriteLine("");
+                Debug.WriteLine($"Profile name: {kvp.Key}");
+                Debug.WriteLine($"  ID :          {kvp.Value.ID}");
+                Debug.WriteLine($"  Interval :    {kvp.Value.Interval}");
+                Debug.WriteLine($"  MaxInterval : {kvp.Value.MaxInterval}");
+                Debug.WriteLine($"  MinInterval : {kvp.Value.MinInterval}");
+                Debug.WriteLine("");
             }
+        }
 
-            WriteDebugLine(sb.ToString());
+        [Conditional("DEBUG")]
+        private static void GetRegisteredProvidersInProcess()
+        {
+            new List<string>(TraceEventProviders.GetRegisteredProvidersInProcess(Process.GetCurrentProcess().Id)
+                .Select(p => TraceEventProviders.GetProviderName(p))).ForEach(name => Debug.WriteLine(name));
         }
     }
 }

--- a/src/xunit.performance.api/ETWProfiler.cs
+++ b/src/xunit.performance.api/ETWProfiler.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using static Microsoft.Xunit.Performance.Api.Common;
 using static Microsoft.Xunit.Performance.Api.Native.Windows.Kernel32;
 using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
 
@@ -36,6 +37,13 @@ namespace Microsoft.Xunit.Performance.Api
         /// <returns></returns>
         public static void Record(string assemblyFileName, string runId, string outputDirectory, Action action, Action<string> collectOutputFilesCallback)
         {
+            if (!IsRunningAsAdministrator)
+            {
+                const string errMessage = "In order to profile, application is required to run as Administrator.";
+                WriteErrorLine(errMessage);
+                throw new InvalidOperationException(errMessage);
+            }
+
             const int bufferSizeMB = 256;
             var sessionName = $"Performance-Api-Session-{runId}";
             var name = $"{runId}-{Path.GetFileNameWithoutExtension(assemblyFileName)}";
@@ -92,7 +100,7 @@ namespace Microsoft.Xunit.Performance.Api
             MarkdownHelper.Write(mdFileName, mdTable);
             WriteInfoLine($"Markdown file saved to \"{mdFileName}\"");
             collectOutputFilesCallback(mdFileName);
-            Console.WriteLine(mdTable);
+            Console.WriteLine(MarkdownHelper.ToTrimmedTable(mdTable));
 
             var csvFileName = Path.Combine(outputDirectory, $"{name}.csv");
             dt.WriteToCSV(csvFileName);

--- a/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
+++ b/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
@@ -8,7 +8,6 @@ using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
 using Microsoft.Xunit.Performance.Sdk;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using System.Linq;
 
 namespace Microsoft.Xunit.Performance.Api

--- a/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
+++ b/src/xunit.performance.api/EtwPerformanceMetricEvaluationContext.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
 using Microsoft.Xunit.Performance.Sdk;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Linq;
 
 namespace Microsoft.Xunit.Performance.Api

--- a/src/xunit.performance.api/MarkdownHelper.cs
+++ b/src/xunit.performance.api/MarkdownHelper.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Xunit.Performance.Api
             const string fixedFotmat = "F3";
             const string scientificNotationFormat = "E3";
             var d = Convert.ToDouble(data);
-            var format = (d != 0 && (d > 99999 || d < 0.001)) ? scientificNotationFormat : fixedFotmat;
+            var format = (d != 0 && (d > 99999 || Math.Abs(d) < 0.001)) ? scientificNotationFormat : fixedFotmat;
             return d.ToString(format, CultureInfo.InvariantCulture);
         }
     }

--- a/src/xunit.performance.api/MarkdownHelper.cs
+++ b/src/xunit.performance.api/MarkdownHelper.cs
@@ -4,9 +4,11 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace Microsoft.Xunit.Performance.Api
 {
+    // TODO: This could be implemented as an extension to the MarkdownLog.Table class
     internal static class MarkdownHelper
     {
         public static void Write(string mdFileName, MarkdownLog.Table mdTable)
@@ -15,8 +17,26 @@ namespace Microsoft.Xunit.Performance.Api
             {
                 using (var sw = new StreamWriter(stream))
                 {
-                    sw.Write(mdTable.ToString());
+                    sw.Write(ToTrimmedTable(mdTable));
                 }
+            }
+        }
+
+        public static string ToTrimmedTable(MarkdownLog.Table mdTable)
+        {
+            using (var sr = new StringReader(mdTable.ToMarkdown()))
+            {
+                string line;
+                var sb = new StringBuilder();
+
+                while ((line = sr.ReadLine()) != null)
+                {
+                    line = line.TrimStart(' ');
+                    line = !line.StartsWith(":") ? $" {line}" : line;
+                    sb.AppendLine(line);
+                }
+
+                return sb.ToString();
             }
         }
 
@@ -74,7 +94,7 @@ namespace Microsoft.Xunit.Performance.Api
             const string fixedFotmat = "F3";
             const string scientificNotationFormat = "E3";
             var d = Convert.ToDouble(data);
-            var format = d > 99999 ? scientificNotationFormat : fixedFotmat;
+            var format = (d != 0 && (d > 99999 || d < 0.001)) ? scientificNotationFormat : fixedFotmat;
             return d.ToString(format, CultureInfo.InvariantCulture);
         }
     }

--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -58,12 +58,15 @@ namespace Microsoft.Xunit.Performance.Api
                         .Where(iter => iter.Iteration.ContainsKey(metric.Name))
                         .Select(iter => iter.Iteration[metric.Name]);
 
-                    var count = values.Count();
-                    if (count == 0) // Cannot compute statistics when there are not results (e.g. user only ran a subset of all tests).
+                    if (values.Count() == 0) // Cannot compute statistics when there are not results (e.g. user only ran a subset of all tests).
                         continue;
 
+                    // Skip the warmup run.
+                    if (values.Count() > 1)
+                        values = values.Skip(1);
+
                     var avg = values.Average();
-                    var stdev_s = Math.Sqrt(values.Sum(x => Math.Pow(x - avg, 2)) / (count - 1));
+                    var stdev_s = Math.Sqrt(values.Sum(x => Math.Pow(x - avg, 2)) / (values.Count() - 1));
                     var max = values.Max();
                     var min = values.Min();
 
@@ -71,7 +74,7 @@ namespace Microsoft.Xunit.Performance.Api
                     newRow[col0_testName] = testModel.Name;
                     newRow[col1_metric] = metric.DisplayName;
 
-                    newRow[col2_iterations] = count.ToString();
+                    newRow[col2_iterations] = values.Count().ToString();
                     newRow[col3_average] = avg.ToString();
                     newRow[col4_stdevs] = stdev_s.ToString();
                     newRow[col5_min] = min.ToString();

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
@@ -7,10 +7,8 @@ namespace Microsoft.Xunit.Performance.Api
 {
     internal class GCAllocatedBytesForCurrentThreadEvaluator : PerformanceMetricEvaluator
     {
-        public GCAllocatedBytesForCurrentThreadEvaluator(PerformanceMetricEvaluationContext context)
+        public GCAllocatedBytesForCurrentThreadEvaluator()
         {
-            _context = context;
-            //_context.TraceEventSource.UserData
         }
 
         public override void BeginIteration(TraceEvent traceEvent)
@@ -25,7 +23,6 @@ namespace Microsoft.Xunit.Performance.Api
                 _bytesBeforeIteration, bytesAfterIteration);
         }
 
-        private readonly PerformanceMetricEvaluationContext _context;
         private long _bytesBeforeIteration;
     }
 }

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
@@ -1,28 +1,18 @@
 ﻿using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
-using Microsoft.Xunit.Performance.Execution;
 using Microsoft.Xunit.Performance.Sdk;
 
 namespace Microsoft.Xunit.Performance.Api
 {
     internal class GCAllocatedBytesForCurrentThreadEvaluator : PerformanceMetricEvaluator
     {
-        public GCAllocatedBytesForCurrentThreadEvaluator()
-        {
-        }
-
         public override void BeginIteration(TraceEvent traceEvent)
         {
-            _bytesBeforeIteration = ((BenchmarkIterationStartArgs)traceEvent).AllocatedBytes;
         }
 
         public override double EndIteration(TraceEvent traceEvent)
         {
-            var bytesAfterIteration = ((BenchmarkIterationStopArgs)traceEvent).AllocatedBytes;
-            return AllocatedBytesForCurrentThread.GetTotalAllocatedBytes(
-                _bytesBeforeIteration, bytesAfterIteration);
+            return ((BenchmarkIterationStopArgs)traceEvent).AllocatedBytes;
         }
-
-        private long _bytesBeforeIteration;
     }
 }

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadEvaluator.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
+using Microsoft.Xunit.Performance.Execution;
+using Microsoft.Xunit.Performance.Sdk;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal class GCAllocatedBytesForCurrentThreadEvaluator : PerformanceMetricEvaluator
+    {
+        public GCAllocatedBytesForCurrentThreadEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            _context = context;
+            //_context.TraceEventSource.UserData
+        }
+
+        public override void BeginIteration(TraceEvent traceEvent)
+        {
+            _bytesBeforeIteration = ((BenchmarkIterationStartArgs)traceEvent).AllocatedBytes;
+        }
+
+        public override double EndIteration(TraceEvent traceEvent)
+        {
+            var bytesAfterIteration = ((BenchmarkIterationStopArgs)traceEvent).AllocatedBytes;
+            return AllocatedBytesForCurrentThread.GetTotalAllocatedBytes(
+                _bytesBeforeIteration, bytesAfterIteration);
+        }
+
+        private readonly PerformanceMetricEvaluationContext _context;
+        private long _bytesBeforeIteration;
+    }
+}

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
@@ -7,8 +7,12 @@ namespace Microsoft.Xunit.Performance.Api
 {
     internal class GCAllocatedBytesForCurrentThreadMetric : PerformanceMetric
     {
+        public static string GetAllocatedBytesForCurrentThreadId => "GC.GetAllocatedBytesForCurrentThread";
+
+        public static string GetAllocatedBytesForCurrentThreadDisplayName => "Allocation Size on Benchmark Execution Thread";
+
         public GCAllocatedBytesForCurrentThreadMetric()
-            : base("GCAllocatedBytesForCurrentThread", "Allocations In Current Thread", PerformanceMetricUnits.Bytes)
+            : base(GetAllocatedBytesForCurrentThreadId, GetAllocatedBytesForCurrentThreadDisplayName, PerformanceMetricUnits.Bytes)
         {
         }
 

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
@@ -19,15 +19,15 @@ namespace Microsoft.Xunit.Performance.Api
                 yield return new UserProviderInfo()
                 {
                     ProviderGuid = MicrosoftXunitBenchmarkTraceEventParser.ProviderGuid,
-                    Level = TraceEventLevel.Informational,
-                    Keywords = ulong.MaxValue
+                    Level = TraceEventLevel.Always,
+                    Keywords = (ulong)KernelTraceEventParser.Keywords.None
                 };
             }
         }
 
         public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
         {
-            return new GCAllocatedBytesForCurrentThreadEvaluator(context);
+            return new GCAllocatedBytesForCurrentThreadEvaluator();
         }
     }
 }

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetric.cs
@@ -1,0 +1,33 @@
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Xunit.Performance.Sdk;
+using System.Collections.Generic;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal class GCAllocatedBytesForCurrentThreadMetric : PerformanceMetric
+    {
+        public GCAllocatedBytesForCurrentThreadMetric()
+            : base("GCAllocatedBytesForCurrentThread", "Allocations In Current Thread", PerformanceMetricUnits.Bytes)
+        {
+        }
+
+        public override IEnumerable<ProviderInfo> ProviderInfo
+        {
+            get
+            {
+                yield return new UserProviderInfo()
+                {
+                    ProviderGuid = MicrosoftXunitBenchmarkTraceEventParser.ProviderGuid,
+                    Level = TraceEventLevel.Informational,
+                    Keywords = ulong.MaxValue
+                };
+            }
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCAllocatedBytesForCurrentThreadEvaluator(context);
+        }
+    }
+}

--- a/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetricDiscoverer.cs
+++ b/src/xunit.performance.api/PerformanceMetric/GCAllocatedBytesForCurrentThreadMetricDiscoverer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Xunit.Performance.Sdk;
+using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace Microsoft.Xunit.Performance.Api
+{
+    internal sealed class GCAllocatedBytesForCurrentThreadMetricDiscoverer : IPerformanceMetricDiscoverer
+    {
+        public IEnumerable<PerformanceMetricInfo> GetMetrics(IAttributeInfo metricAttribute)
+        {
+            yield return new GCAllocatedBytesForCurrentThreadMetric();
+        }
+    }
+}

--- a/src/xunit.performance.api/XunitBenchmark.cs
+++ b/src/xunit.performance.api/XunitBenchmark.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Xunit.Performance.Api
                     else
                     {
                         WriteWarningLine(AllocatedBytesForCurrentThread.NoAvailabilityReason);
-                        WriteWarningLine("The 'Allocations In Current Thread' metric will not be collected.");
+                        WriteWarningLine($"The '{GCAllocatedBytesForCurrentThreadMetric.GetAllocatedBytesForCurrentThreadDisplayName}' metric will not be collected.");
                     }
 
                     // Inject implicit pmc counters

--- a/src/xunit.performance.api/XunitBenchmark.cs
+++ b/src/xunit.performance.api/XunitBenchmark.cs
@@ -93,7 +93,10 @@ namespace Microsoft.Xunit.Performance.Api
                     // Inject implicit pmc counters
                     foreach (var test in testMessageVisitor.Tests)
                     {
-                        var metrics = new List<PerformanceMetricInfo>(test.Metrics);
+                        var metrics = new List<PerformanceMetricInfo>(test.Metrics)
+                        {
+                            new GCAllocatedBytesForCurrentThreadMetric()
+                        };
                         foreach (var performanceMetricInfo in PerformanceMetricInfos)
                             if (performanceMetricInfo.IsValidPmc)
                                 metrics.Add(performanceMetricInfo);

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using static Microsoft.Xunit.Performance.Api.Common;
-using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
+using static Microsoft.Xunit.Performance.Api.PerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
+using static Microsoft.Xunit.Performance.Api.Common;
 using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
@@ -10,8 +10,6 @@ namespace Microsoft.Xunit.Performance.Api
     {
         static XunitPerformanceHarness()
         {
-            s_isWindowsPlatform = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
             Action<string, string, string, Action, Action<string>> etwProfiler = (assemblyPath, runId, outputDirectory, runner, collectOutputFilesCallback) =>
             {
                 ETWProfiler.Record(assemblyPath, runId, outputDirectory, runner, collectOutputFilesCallback);
@@ -20,7 +18,7 @@ namespace Microsoft.Xunit.Performance.Api
             {
                 GenericProfiler.Record(assemblyPath, runId, outputDirectory, runner, collectOutputFilesCallback);
             };
-            s_profiler = s_isWindowsPlatform ? etwProfiler : genericProfiler;
+            s_profiler = IsWindowsPlatform ? etwProfiler : genericProfiler;
         }
 
         public XunitPerformanceHarness(string[] args)
@@ -66,7 +64,7 @@ namespace Microsoft.Xunit.Performance.Api
                 _runner(assemblyPath);
                 ProcessResults(assemblyPath, Configuration.RunId, _outputDirectory, collectOutputFilesCallback);
             };
-            Action runner = s_isWindowsPlatform ? winRunner : nixRunner;
+            Action runner = IsWindowsPlatform ? winRunner : nixRunner;
 
             s_profiler(assemblyPath, Configuration.RunId, _outputDirectory, runner, collectOutputFilesCallback);
         }
@@ -151,7 +149,6 @@ namespace Microsoft.Xunit.Performance.Api
 
         #endregion IDisposable implementation
 
-        private static readonly bool s_isWindowsPlatform;
         private static readonly Action<string, string, string, Action, Action<string>> s_profiler;
 
         private readonly Action<string> _runner;

--- a/src/xunit.performance.api/XunitPerformanceHarnessOptions.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarnessOptions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -102,6 +103,10 @@ namespace Microsoft.Xunit.Performance.Api
                                         $"Missing value option for {(error as MissingValueOptionError).NameInfo.NameText}");
                                 case ErrorType.HelpRequestedError:
                                     Console.WriteLine(Usage());
+                                    Environment.Exit(0);
+                                    break;
+                                case ErrorType.VersionRequestedError:
+                                    Console.WriteLine(new AssemblyName(typeof(XunitPerformanceHarnessOptions).GetTypeInfo().Assembly.FullName).Version);
                                     Environment.Exit(0);
                                     break;
                                 case ErrorType.BadFormatTokenError:

--- a/src/xunit.performance.api/XunitRunner.cs
+++ b/src/xunit.performance.api/XunitRunner.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using Xunit.Abstractions;

--- a/src/xunit.performance.api/XunitRunner.cs
+++ b/src/xunit.performance.api/XunitRunner.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading;
 using Xunit.Abstractions;
 using Xunit.Runners;
-using static Microsoft.Xunit.Performance.Api.XunitPerformanceLogger;
+using static Microsoft.Xunit.Performance.Api.PerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -113,6 +113,7 @@ namespace Microsoft.Xunit.Performance.Api
             {
                 lock (consoleLock)
                 {
+                    // TODO: Stop reporting performance results of failed test!
                     WriteErrorLine($"{info.TestDisplayName}: {info.ExceptionMessage}");
 
                     if (info.ExceptionStackTrace != null)

--- a/src/xunit.performance.api/XunitRunner.cs
+++ b/src/xunit.performance.api/XunitRunner.cs
@@ -78,8 +78,9 @@ namespace Microsoft.Xunit.Performance.Api
                         // TODO: Add error handling. Throwing exception is not enough because we are waiting for the async runner to finish.
                         WriteErrorLine("There are more benchmarks than facts.");
                     }
-                    var message = (diff == 0) ? $"Running {info.TestCasesToRun} Benchmarks..." : $"Running {info.TestCasesToRun} Benchmarks out of {info.TestCasesDiscovered} Xunit Facts...";
-                    WriteInfoLine(message);
+                    WriteInfoLine($"Running {info.TestCasesToRun} [Benchmark]s");
+                    if (diff != 0)
+                        WriteInfoLine($"Skipping {diff} Xunit [Fact]s because they are not [Benchmark]s");
                 }
             };
             runner.OnErrorMessage = info =>

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -20,16 +20,13 @@
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="xunit.runner.utility" Version="2.2.0-beta2-build3300" />

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.2-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />

--- a/src/xunit.performance.core/ConsoleOutput/PerformanceLogger.cs
+++ b/src/xunit.performance.core/ConsoleOutput/PerformanceLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -8,7 +9,7 @@ namespace Microsoft.Xunit.Performance.Api
     /// to log: information, warning, errors and debug messages in a standard
     /// way with timestamp.
     /// </summary>
-    internal static class XunitPerformanceLogger
+    internal static class PerformanceLogger
     {
         public static void WriteInfoLine(string value)
         {
@@ -33,21 +34,23 @@ namespace Microsoft.Xunit.Performance.Api
 
         private static void WriteLine(string value, ConsoleColor background, ConsoleColor foreground)
         {
-            using (var conColor = new ConColor(background, foreground))
+            using (var conColor = new ConsoleSettings(background, foreground))
                 Console.Out.WriteLine($"[{DateTime.Now}]{value}");
         }
 
-        private sealed class ConColor : IDisposable
+        private sealed class ConsoleSettings : IDisposable
         {
-            public ConColor(ConsoleColor background, ConsoleColor foreground)
+            public ConsoleSettings(ConsoleColor background, ConsoleColor foreground)
             {
                 // Save previous setting.
                 _background = Console.BackgroundColor;
                 _foreground = Console.ForegroundColor;
+                _encoding = Console.OutputEncoding;
 
                 // Set new setting.
                 Console.BackgroundColor = background;
                 Console.ForegroundColor = foreground;
+                Console.OutputEncoding = Encoding.UTF8;
             }
 
             public void Dispose()
@@ -55,10 +58,12 @@ namespace Microsoft.Xunit.Performance.Api
                 // Restore previous setting.
                 Console.BackgroundColor = _background;
                 Console.ForegroundColor = _foreground;
+                Console.OutputEncoding = _encoding;
             }
 
-            private ConsoleColor _background;
-            private ConsoleColor _foreground;
+            private readonly ConsoleColor _background;
+            private readonly ConsoleColor _foreground;
+            private readonly Encoding _encoding;
         }
     }
 }

--- a/src/xunit.performance.core/Properties/AssemblyInfo.cs
+++ b/src/xunit.performance.core/Properties/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: Xunit.Sdk.PlatformSpecificAssembly]
+[assembly: InternalsVisibleTo("xunit.performance.execution, PublicKey=" +
+    "002400000480000094000000060200000024000052534131000400000100010099b48762d2238a" +
+    "6917bbbff1dc9787fa10251039b421c621fb37f6c539b912bb69627fbed5b0c267fcc687504481" +
+    "07dcd5d6da22b6ddcaf2d96037f3bbf5030bd1c33474402f369735b0615c0ce6face3b9033a979" +
+    "bc4ebc504773c60e5f48a0b09b18b5806bccc12c03858c0141e0e5270e48830ebfaec006071bd2" +
+    "830559e2")]
+[assembly: InternalsVisibleTo("xunit.performance.metrics, PublicKey=" +
+    "002400000480000094000000060200000024000052534131000400000100010099b48762d2238a" +
+    "6917bbbff1dc9787fa10251039b421c621fb37f6c539b912bb69627fbed5b0c267fcc687504481" +
+    "07dcd5d6da22b6ddcaf2d96037f3bbf5030bd1c33474402f369735b0615c0ce6face3b9033a979" +
+    "bc4ebc504773c60e5f48a0b09b18b5806bccc12c03858c0141e0e5270e48830ebfaec006071bd2" +
+    "830559e2")]
+[assembly: InternalsVisibleTo("xunit.performance.api, PublicKey=" +
+    "002400000480000094000000060200000024000052534131000400000100010099b48762d2238a" +
+    "6917bbbff1dc9787fa10251039b421c621fb37f6c539b912bb69627fbed5b0c267fcc687504481" +
+    "07dcd5d6da22b6ddcaf2d96037f3bbf5030bd1c33474402f369735b0615c0ce6face3b9033a979" +
+    "bc4ebc504773c60e5f48a0b09b18b5806bccc12c03858c0141e0e5270e48830ebfaec006071bd2" +
+    "830559e2")]

--- a/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
+++ b/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xunit.Performance.Execution
                 else
                 {
                     IsAvailable = false;
-                    NoAvailabilityReason = "There is a bug on the GC.GetAllocatedBytesForCurrentThread implementation for this version of netcoreapp.";
+                    NoAvailabilityReason = "Not capturing because the targeted runtime does not contain the fix for 'https://github.com/dotnet/coreclr/issues/10207'";
                 }
             }
 

--- a/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
+++ b/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Reflection;
+
+namespace Microsoft.Xunit.Performance.Execution
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    internal static class AllocatedBytesForCurrentThread
+    {
+        /// <summary>
+        /// Loads the GetAllocatedBytesForCurrentThread method.
+        /// </summary>
+        /// <remarks>
+        /// Calling `gcGetAllocMethod.Invoke(null, null);` will cause an object
+        /// to be returned (it allocates a minimum object), so calling the
+        /// method back to back and computing the difference between them will
+        /// not be equals to zero (it will differ by 24 bytes).
+        /// </remarks>
+        static AllocatedBytesForCurrentThread()
+        {
+            var typeInfo = typeof(GC).GetTypeInfo();
+            var method = typeInfo.GetMethod("GetAllocatedBytesForCurrentThread",
+                            BindingFlags.Public | BindingFlags.Static)
+                      ?? typeInfo.GetMethod("GetAllocatedBytesForCurrentThread",
+                            BindingFlags.NonPublic | BindingFlags.Static);
+
+            // TODO: Add meaningful error message.
+
+            _GetAllocatedBytesForCurrentThread = method == null ?
+                (Func<long>)(() => 0xBAAAAAAD) : () => (long)method.Invoke(null, null);
+
+            var allocatedBytesBefore = LastAllocatedBytes;
+            var allocatedBytesAfter = LastAllocatedBytes;
+            s_minAllocatedBytes = allocatedBytesAfter - allocatedBytesBefore;
+        }
+
+        public static long LastAllocatedBytes => _GetAllocatedBytesForCurrentThread.Invoke();
+
+        public static long GetTotalAllocatedBytes(long allocatedBytesBefore, long allocatedBytesAfter)
+        {
+            return allocatedBytesAfter - allocatedBytesBefore; // FIXME: (allocatedBytesAfter - allocatedBytesBefore - s_minAllocatedBytes) sometimes returns a negative value!
+        }
+
+        private static readonly Func<long> _GetAllocatedBytesForCurrentThread;
+        private static readonly long s_minAllocatedBytes;
+    }
+}

--- a/src/xunit.performance.execution/BenchmarkEventSource.cs
+++ b/src/xunit.performance.execution/BenchmarkEventSource.cs
@@ -131,10 +131,7 @@ namespace Microsoft.Xunit.Performance
                 WriteCSV(BenchmarkName, stopReason: StopReason);
         }
 
-        [Event(3,
-            Level = EventLevel.LogAlways,
-            Opcode = EventOpcode.Start,
-            Task = Tasks.BenchmarkIteration)]
+        [Event(3, Level = EventLevel.LogAlways, Opcode = EventOpcode.Start, Task = Tasks.BenchmarkIteration)]
         public unsafe void BenchmarkIterationStart(string RunId, string BenchmarkName, int Iteration, long AllocatedBytes)
         {
             if (_csvWriter != null)
@@ -165,10 +162,7 @@ namespace Microsoft.Xunit.Performance
             }
         }
 
-        [Event(4,
-            Level = EventLevel.LogAlways,
-            Opcode = EventOpcode.Stop,
-            Task = Tasks.BenchmarkIteration)]
+        [Event(4, Level = EventLevel.LogAlways, Opcode = EventOpcode.Stop, Task = Tasks.BenchmarkIteration)]
         public unsafe void BenchmarkIterationStop(string RunId, string BenchmarkName, int Iteration, long AllocatedBytes)
         {
             if (IsEnabled())

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Xunit.Performance
                 _overallTimer = new Stopwatch();
                 _currentIteration = -1;
                 _innerIterations = innerIterationsCount;
-                if(_innerIterations > 1)
+                if (_innerIterations > 1)
                 {
                     _maxIterations = BenchmarkConfiguration.Instance.MaxIterationWhenInnerSpecified;
                 }
@@ -125,7 +125,7 @@ namespace Microsoft.Xunit.Performance
                         return true;
                     }
 
-                    if (_currentIteration > BenchmarkConfiguration.Instance.MinIteration && 
+                    if (_currentIteration > BenchmarkConfiguration.Instance.MinIteration &&
                         _overallTimer.ElapsedMilliseconds > BenchmarkConfiguration.Instance.MaxTotalMilliseconds)
                     {
                         IterationStopReason = "MaxTime";
@@ -149,7 +149,7 @@ namespace Microsoft.Xunit.Performance
 
             private IEnumerable<BenchmarkIteration> GetIterations()
             {
-                GC.Collect(2);
+                GC.Collect(2, GCCollectionMode.Forced);
                 GC.WaitForPendingFinalizers();
 
                 for (_currentIteration = 0; !DoneIterating; _currentIteration++)
@@ -190,7 +190,7 @@ namespace Microsoft.Xunit.Performance
 
                     RandomizeMeasurementStartTime();
 
-                    BenchmarkEventSource.Log.BenchmarkIterationStart(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber);
+                    BenchmarkEventSource.Log.BenchmarkIterationStart(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber, 0);
                 }
             }
 
@@ -252,7 +252,7 @@ namespace Microsoft.Xunit.Performance
                     Debug.Assert(_currentIterationMeasurementStarted);
                     _currentIterationMesaurementStopped = true;
 
-                    BenchmarkEventSource.Log.BenchmarkIterationStop(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber);
+                    BenchmarkEventSource.Log.BenchmarkIterationStop(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber, 0);
                 }
             }
         }

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Xunit.Performance
                 }
             }
 
-            protected override IEnumerable<BenchmarkIteration> Iterations
+            protected internal override IEnumerable<BenchmarkIteration> Iterations
             {
                 get
                 {
@@ -171,7 +171,7 @@ namespace Microsoft.Xunit.Performance
                 }
             }
 
-            protected override long InnerIterationCount
+            protected internal override long InnerIterationCount
             {
                 get
                 {
@@ -179,7 +179,7 @@ namespace Microsoft.Xunit.Performance
                 }
             }
 
-            protected override void StartMeasurement(int iterationNumber)
+            protected internal override void StartMeasurement(int iterationNumber)
             {
                 if (iterationNumber == _currentIteration)
                 {
@@ -190,7 +190,7 @@ namespace Microsoft.Xunit.Performance
 
                     RandomizeMeasurementStartTime();
 
-                    BenchmarkEventSource.Log.BenchmarkIterationStart(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber, 0);
+                    BenchmarkEventSource.Log.BenchmarkIterationStart(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber);
                 }
             }
 
@@ -245,14 +245,14 @@ namespace Microsoft.Xunit.Performance
                     Volatile.Read(ref _randomDelayGenerator);
             }
 
-            protected override void StopMeasurement(int iterationNumber)
+            protected internal override void StopMeasurement(int iterationNumber)
             {
                 if (iterationNumber == _currentIteration && !_currentIterationMesaurementStopped)
                 {
                     Debug.Assert(_currentIterationMeasurementStarted);
                     _currentIterationMesaurementStopped = true;
 
-                    BenchmarkEventSource.Log.BenchmarkIterationStop(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber, 0);
+                    BenchmarkEventSource.Log.BenchmarkIterationStop(BenchmarkConfiguration.Instance.RunId, _testName, iterationNumber);
                 }
             }
         }

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -22,9 +22,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\xunit.performance.core\xunit.performance.core.csproj" />
-    <!--<ProjectReference Include="..\xunit.performance.core\xunit.performance.core.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>-->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.execution</AssemblyTitle>
     <Description>xUnit Performance Execution</Description>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <Title>xUnit Performance Core</Title>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/xunit.performance.metrics/Microsoft-Xunit-Benchmark.manifest.cs
+++ b/src/xunit.performance.metrics/Microsoft-Xunit-Benchmark.manifest.cs
@@ -13,13 +13,14 @@ using System.Text;
 namespace Microsoft.Diagnostics.Tracing.Parsers
 {
     using Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark;
+    using Microsoft.Diagnostics.Tracing.Session;
 
     [System.CodeDom.Compiler.GeneratedCode("traceparsergen", "2.0")]
     public sealed class MicrosoftXunitBenchmarkTraceEventParser : TraceEventParser
     {
         public static string ProviderName => "Microsoft-Xunit-Benchmark";
 
-        public static Guid ProviderGuid => Guid.Parse("A3B447A8-6549-4158-9BAD-76D442A47061");
+        public static Guid ProviderGuid => TraceEventProviders.GetEventSourceGuidFromName(ProviderName);
 
         public enum Keywords : long
         {
@@ -140,7 +141,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
         public string RunId { get { return GetUnicodeStringAt(0); } }
         public string BenchmarkName { get { return GetUnicodeStringAt(SkipUnicodeString(0)); } }
         public int Iteration { get { return GetInt32At(SkipUnicodeString(SkipUnicodeString(0))); } }
-        public long AllocatedBytes { get { return GetInt64At(SkipUnicodeString(SkipUnicodeString(0)) + 4); } }
 
         #region Private
         internal BenchmarkIterationStartArgs(Action<BenchmarkIterationStartArgs> target, int eventID, int task, string taskName, Guid taskGuid, int opcode, string opcodeName, Guid providerGuid, string providerName)
@@ -168,7 +168,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
             XmlAttrib(sb, "RunId", RunId);
             XmlAttrib(sb, "BenchmarkName", BenchmarkName);
             XmlAttrib(sb, "Iteration", Iteration);
-            XmlAttrib(sb, "AllocatedBytes", AllocatedBytes);
             sb.Append("/>");
             return sb;
         }
@@ -178,7 +177,7 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
             get
             {
                 if (payloadNames == null)
-                    payloadNames = new string[] { "RunId", "BenchmarkName", "Iteration", "AllocatedBytes" };
+                    payloadNames = new string[] { "RunId", "BenchmarkName", "Iteration" };
                 return payloadNames;
             }
         }
@@ -193,8 +192,6 @@ namespace Microsoft.Diagnostics.Tracing.Parsers.MicrosoftXunitBenchmark
                     return BenchmarkName;
                 case 2:
                     return Iteration;
-                case 3:
-                    return AllocatedBytes;
                 default:
                     Debug.Assert(false, "Bad field index");
                     return null;

--- a/src/xunit.performance.metrics/PerformanceMetricEvaluationContext.cs
+++ b/src/xunit.performance.metrics/PerformanceMetricEvaluationContext.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Diagnostics.Tracing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Xunit.Performance.Sdk
 {

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.2-alpha-experimental" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.metrics</AssemblyTitle>
     <Description>xUnit Performance Metrics</Description>
-    <TargetFrameworks>netstandard1.5</TargetFrameworks>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <Title>xUnit Performance Metrics</Title>
 
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.metrics</AssemblyTitle>
     <Description>xUnit Performance Metrics</Description>
-    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5</TargetFrameworks>
     <Title>xUnit Performance Metrics</Title>
 
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
@@ -19,25 +19,14 @@
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\xunit.performance.core\xunit.performance.core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.41" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net46' ">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/simpleharness/EmptyBenchmarkTest.cs
+++ b/tests/simpleharness/EmptyBenchmarkTest.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Xunit.Performance;
+
+namespace simpleharness
+{
+    public class EmptyBenchmarkTest
+    {
+        [Benchmark]
+        public static void Implementation_1()
+        {
+            foreach (BenchmarkIteration iter in Benchmark.Iterations)
+            {
+                using (iter.StartMeasurement())
+                {
+                }
+            }
+        }
+
+        [Benchmark]
+        public static void Implementation_2()
+        {
+            Benchmark.Iterate(() => { /*do nothing*/ });
+        }
+    }
+}

--- a/tests/simpleharness/GetAllocatedBytesForCurrentThreadTest.cs
+++ b/tests/simpleharness/GetAllocatedBytesForCurrentThreadTest.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Xunit.Performance;
+using System;
+using System.Reflection;
+
+namespace simpleharness
+{
+    public class GetAllocatedBytesForCurrentThreadTest
+    {
+        [Benchmark]
+        public static void WithCollect()
+        {
+            var method = typeof(GC)
+                .GetTypeInfo()
+                .GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+            var nBytesBefore = (long)method.Invoke(null, null);
+            var nBytesAfter = (long)method.Invoke(null, null);
+            var nBytesExtra = nBytesAfter - nBytesBefore;
+
+            foreach (BenchmarkIteration iter in Benchmark.Iterations)
+            {
+                using (iter.StartMeasurement())
+                {
+                    for (int i = 0; i < 1000; ++i)
+                    {
+                        GC.Collect();
+                        nBytesBefore = (long)method.Invoke(null, null);
+                        GC.Collect();
+                        nBytesAfter = (long)method.Invoke(null, null);
+
+                        var totalAllocatedBytes = nBytesAfter - (nBytesBefore + nBytesExtra);
+                        if (totalAllocatedBytes != 0)
+                            throw new Exception($"Unexpected number of bytes. [{i}]: {totalAllocatedBytes} bytes");
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public static void WithoutCollect()
+        {
+            var method = typeof(GC)
+                .GetTypeInfo()
+                .GetMethod("GetAllocatedBytesForCurrentThread", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+
+            var nBytesBefore = (long)method.Invoke(null, null);
+            var nBytesAfter = (long)method.Invoke(null, null);
+            var nBytesExtra = nBytesAfter - nBytesBefore;
+
+            Benchmark.Iterate(() =>
+            {
+                for (int i = 0; i < 1000; ++i)
+                {
+                    nBytesBefore = (long)method.Invoke(null, null);
+                    nBytesAfter = (long)method.Invoke(null, null);
+
+                    var totalAllocatedBytes = nBytesAfter - (nBytesBefore + nBytesExtra);
+                    if (totalAllocatedBytes != 0)
+                        throw new Exception($"Unexpected number of bytes. [{i}]: {totalAllocatedBytes} bytes");
+                }
+            });
+        }
+    }
+}

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -32,7 +32,7 @@ namespace simpleharness
 
         [Benchmark(InnerIterationCount = 10)]
         [MemberData(nameof(InputData))]
-        private static void TestMultipleStringInputs(string[] args)
+        public static void TestMultipleStringInputs(string[] args)
         {
             foreach (BenchmarkIteration iter in Benchmark.Iterations)
             {
@@ -65,17 +65,6 @@ namespace simpleharness
                         {
                             string.Format("{0}{1}{2}{3}", "a", "b", "c", "d");
                         }
-                    }
-                }
-            }
-
-            [Benchmark]
-            private static void EmptyBenchmark()
-            {
-                foreach (BenchmarkIteration iter in Benchmark.Iterations)
-                {
-                    using (iter.StartMeasurement())
-                    {
                     }
                 }
             }
@@ -163,6 +152,20 @@ namespace simpleharness
                 }
 
                 return deck;
+            }
+        }
+
+        public static class Type_3
+        {
+            [Benchmark]
+            public static void EmptyBenchmark()
+            {
+                foreach (BenchmarkIteration iter in Benchmark.Iterations)
+                {
+                    using (iter.StartMeasurement())
+                    {
+                    }
+                }
             }
         }
     }

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -25,7 +25,7 @@ namespace simpleharness
 
         public static IEnumerable<object[]> InputData()
         {
-            var args = new string[] { "FFT", "LU", "MC", "MM", "SOR", "\u03C3", "x\u0305" };
+            var args = new string[] { "FOO", "\u03C3", "x\u0305" };
             foreach (var arg in args)
                 yield return new object[] { new string[] { arg } };
         }
@@ -34,16 +34,16 @@ namespace simpleharness
         [MemberData(nameof(InputData))]
         private static void TestMultipleStringInputs(string[] args)
         {
-           foreach (BenchmarkIteration iter in Benchmark.Iterations)
-           {
-               using (iter.StartMeasurement())
-               {
-                   for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                   {
-                       FormattedString(args[0], args[0], args[0], args[0]);
-                   }
-               }
-           }
+            foreach (BenchmarkIteration iter in Benchmark.Iterations)
+            {
+                using (iter.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        FormattedString(args[0], args[0], args[0], args[0]);
+                    }
+                }
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -65,6 +65,17 @@ namespace simpleharness
                         {
                             string.Format("{0}{1}{2}{3}", "a", "b", "c", "d");
                         }
+                    }
+                }
+            }
+
+            [Benchmark]
+            private static void EmptyBenchmark()
+            {
+                foreach (BenchmarkIteration iter in Benchmark.Iterations)
+                {
+                    using (iter.StartMeasurement())
+                    {
                     }
                 }
             }

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -7,12 +7,11 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit;
 
-[assembly: MeasureGCAllocations]
-[assembly: MeasureGCCounts]
 [assembly: MeasureInstructionsRetired]
 
 namespace simpleharness
 {
+    [MeasureGCAllocations]
     public class Program
     {
         public static void Main(string[] args)
@@ -30,6 +29,7 @@ namespace simpleharness
                 yield return new object[] { new string[] { arg } };
         }
 
+        [MeasureGCCounts]
         [Benchmark(InnerIterationCount = 10)]
         [MemberData(nameof(InputData))]
         public static void TestMultipleStringInputs(string[] args)
@@ -52,8 +52,10 @@ namespace simpleharness
             return string.Format("{0}{1}{2}{3}", a, b, c, d);
         }
 
+        [MeasureGCAllocations]
         public sealed class Type_1
         {
+            [MeasureGCCounts]
             [Benchmark(InnerIterationCount = 10000)]
             public void TestBenchmark()
             {
@@ -152,20 +154,6 @@ namespace simpleharness
                 }
 
                 return deck;
-            }
-        }
-
-        public static class Type_3
-        {
-            [Benchmark]
-            public static void EmptyBenchmark()
-            {
-                foreach (BenchmarkIteration iter in Benchmark.Iterations)
-                {
-                    using (iter.StartMeasurement())
-                    {
-                    }
-                }
             }
         }
     }

--- a/tests/simpleharness/simpleharness.csproj
+++ b/tests/simpleharness/simpleharness.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/simpleharness/simpleharness.csproj
+++ b/tests/simpleharness/simpleharness.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/standalonesample/standalonesample.csproj
+++ b/tests/standalonesample/standalonesample.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.2-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />


### PR DESCRIPTION
1. Updated how small decimal numbers are displayed on the statistics
2. Started initial work to gather the allocated bytes in the current thread (this work on .NET Core 1.1)
3. Trimmed the markdown string, which was not being rendered as a table on GitHub
4. Updated build script (disabled old runner from building from the script and made the api the main and only project to be built)