### PR TITLE
Small fixes

### DIFF
--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -230,12 +230,15 @@ namespace Microsoft.Xunit.Performance.Api
                         .Where(iter => iter.Iteration.ContainsKey(metric.Name))
                         .Select(iter => iter.Iteration[metric.Name]);
 
-                    var count = values.Count();
-                    if (count == 0) // Cannot compute statistics when there are not results (e.g. user only ran a subset of all tests).
+                    if (values.Count() == 0) // Cannot compute statistics when there are not results (e.g. user only ran a subset of all tests).
                         continue;
 
+                    // Skip the warmup run.
+                    if (values.Count() > 1)
+                        values = values.Skip(1);
+
                     var avg = values.Average();
-                    var stdev_s = Math.Sqrt(values.Sum(x => Math.Pow(x - avg, 2)) / (count - 1));
+                    var stdev_s = Math.Sqrt(values.Sum(x => Math.Pow(x - avg, 2)) / (values.Count() - 1));
                     var max = values.Max();
                     var min = values.Min();
 
@@ -243,7 +246,7 @@ namespace Microsoft.Xunit.Performance.Api
                     newRow[col0_testName] = test.Name;
                     newRow[col1_metric] = metric.DisplayName;
 
-                    newRow[col2_iterations] = count.ToString();
+                    newRow[col2_iterations] = values.Count().ToString();
                     newRow[col3_average] = avg.ToString();
                     newRow[col4_stdevs] = stdev_s.ToString();
                     newRow[col5_min] = min.ToString();

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Xunit.Performance.Api
         where T : class, IDisposable
     {
         /// <summary>
-        /// Initializes a new instance of the SafeTerminateHandler<T> class that
+        /// Initializes a new instance of the SafeTerminateHandler&lt;T&gt; class that
         /// wraps a disposable object that will be created by calling the
         /// specified callback Func.
         /// </summary>

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -13,27 +13,41 @@ namespace Microsoft.Xunit.Performance.Api
         /// Initializes a new instance of the ScenarioConfiguration class.
         /// </summary>
         /// <param name="timeSpan">The amount of time to wait for one iteration process to exit.</param>
-        /// <param name="iterations">Number of times a benchmark scenario process will be executed.</param>
-        /// <param name="validExitCodes">
-        /// A collection of exit codes that indicates success when the benchmark scenario process terminates.
-        /// If this parameter is not specified, then the only valid exit code will 0.
-        /// </param>
-        public ScenarioConfiguration(TimeSpan timeSpan, int iterations = 10, IEnumerable<int> validExitCodes = null)
+        public ScenarioConfiguration(TimeSpan timeSpan)
         {
-            if (timeSpan.TotalMilliseconds <= 0)
+            if (timeSpan.TotalMilliseconds < 1)
                 throw new InvalidOperationException("The time out per iteration must be a positive number.");
-            if (iterations <= 1)
-                throw new InvalidOperationException("The number of iterations must be greater than 1.");
 
-            Iterations = iterations;
+            Iterations = 10;
             TimeoutPerIteration = timeSpan;
-            ValidExitCodes = validExitCodes != null ? new List<int>(validExitCodes) : new List<int> { 0 };
+            ValidExitCodes = new[] { 0 };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ScenarioConfiguration class (deep copy).
+        /// </summary>
+        /// <param name="scenarioConfiguration">An instance of the ScenarioConfiguration class</param>
+        public ScenarioConfiguration(ScenarioConfiguration scenarioConfiguration)
+        {
+            Iterations = scenarioConfiguration.Iterations;
+            TimeoutPerIteration = scenarioConfiguration.TimeoutPerIteration;
+            ValidExitCodes = scenarioConfiguration.ValidExitCodes;
         }
 
         /// <summary>
         /// Number of times a benchmark scenario process will be executed.
         /// </summary>
-        public int Iterations { get; }
+        public int Iterations
+        {
+            get => _iterations;
+
+            set
+            {
+                if (value < 1)
+                    throw new InvalidOperationException("The number of iterations must be greater than 0.");
+                _iterations = value;
+            }
+        }
 
         /// <summary>
         /// The amount of time to wait for one iteration process to exit.
@@ -42,7 +56,24 @@ namespace Microsoft.Xunit.Performance.Api
 
         /// <summary>
         /// Exit codes that indicates success when the benchmark scenario process terminates.
+        /// If this parameter is not specified, then the only valid exit code will 0.
         /// </summary>
-        public IEnumerable<int> ValidExitCodes { get; }
+        public IEnumerable<int> ValidExitCodes
+        {
+            get => _validExitCodes;
+
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException($"Assigned a null collection to {nameof(ValidExitCodes)}.");
+                if (value.Count() == 0)
+                    throw new InvalidOperationException($"Assigned an empty collection to {nameof(ValidExitCodes)}");
+
+                _validExitCodes = value.ToArray();
+            }
+        }
+
+        private int _iterations;
+        private IEnumerable<int> _validExitCodes;
     }
 }

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -10,17 +10,17 @@ namespace Microsoft.Xunit.Performance.Api
         /// <summary>
         /// Initializes a new instance of the ScenarioConfiguration class.
         /// </summary>
-        /// <param name="timeSpam">The amount of time to wait for one iteration process to exit.</param>
+        /// <param name="timeSpan">The amount of time to wait for one iteration process to exit.</param>
         /// <param name="iterations">Number of times a benchmark scenario process will be executed.</param>
-        public ScenarioConfiguration(TimeSpan timeSpam, int iterations = 10)
+        public ScenarioConfiguration(TimeSpan timeSpan, int iterations = 10)
         {
-            if (timeSpam.TotalMilliseconds <= 0)
+            if (timeSpan.TotalMilliseconds <= 0)
                 throw new InvalidOperationException("The time out per iteration must be a positive number.");
             if (iterations <= 1)
                 throw new InvalidOperationException("The number of iterations must be greater than 1.");
 
             Iterations = iterations;
-            TimeoutPerIteration = timeSpam;
+            TimeoutPerIteration = timeSpan;
         }
 
         /// <summary>

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -12,7 +14,11 @@ namespace Microsoft.Xunit.Performance.Api
         /// </summary>
         /// <param name="timeSpan">The amount of time to wait for one iteration process to exit.</param>
         /// <param name="iterations">Number of times a benchmark scenario process will be executed.</param>
-        public ScenarioConfiguration(TimeSpan timeSpan, int iterations = 10)
+        /// <param name="validExitCodes">
+        /// A collection of exit codes that indicates success when the benchmark scenario process terminates.
+        /// If this parameter is not specified, then the only valid exit code will 0.
+        /// </param>
+        public ScenarioConfiguration(TimeSpan timeSpan, int iterations = 10, IEnumerable<int> validExitCodes = null)
         {
             if (timeSpan.TotalMilliseconds <= 0)
                 throw new InvalidOperationException("The time out per iteration must be a positive number.");
@@ -21,6 +27,7 @@ namespace Microsoft.Xunit.Performance.Api
 
             Iterations = iterations;
             TimeoutPerIteration = timeSpan;
+            ValidExitCodes = validExitCodes != null ? new List<int>(validExitCodes) : new List<int> { 0 };
         }
 
         /// <summary>
@@ -32,5 +39,10 @@ namespace Microsoft.Xunit.Performance.Api
         /// The amount of time to wait for one iteration process to exit.
         /// </summary>
         public TimeSpan TimeoutPerIteration { get; }
+
+        /// <summary>
+        /// Exit codes that indicates success when the benchmark scenario process terminates.
+        /// </summary>
+        public IEnumerable<int> ValidExitCodes { get; }
     }
 }

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xunit.Performance.Api
         /// <param name="iterations">Number of times a benchmark scenario process will be executed.</param>
         public ScenarioConfiguration(TimeSpan timeSpam, int iterations = 10)
         {
-            if (timeSpam.Milliseconds <= 0)
+            if (timeSpam.TotalMilliseconds <= 0)
                 throw new InvalidOperationException("The time out per iteration must be a positive number.");
             if (iterations <= 1)
                 throw new InvalidOperationException("The number of iterations must be greater than 1.");

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Xunit.Performance.Api
 
             Iterations = 10;
             TimeoutPerIteration = timeSpan;
-            ValidExitCodes = new[] { 0 };
+            SuccessExitCodes = new[] { 0 };
         }
 
         /// <summary>
@@ -31,12 +31,17 @@ namespace Microsoft.Xunit.Performance.Api
         {
             Iterations = scenarioConfiguration.Iterations;
             TimeoutPerIteration = scenarioConfiguration.TimeoutPerIteration;
-            ValidExitCodes = scenarioConfiguration.ValidExitCodes;
+            SuccessExitCodes = scenarioConfiguration.SuccessExitCodes;
         }
 
         /// <summary>
         /// Number of times a benchmark scenario process will be executed.
         /// </summary>
+        /// <remarks>
+        /// If the specified number of iterations is greater than 1, then we
+        /// will consider the first iteration as a warm-up and discard its
+        /// result when computing the statistics.
+        /// </remarks>
         public int Iterations
         {
             get => _iterations;
@@ -58,22 +63,22 @@ namespace Microsoft.Xunit.Performance.Api
         /// Exit codes that indicates success when the benchmark scenario process terminates.
         /// If this parameter is not specified, then the only valid exit code will 0.
         /// </summary>
-        public IEnumerable<int> ValidExitCodes
+        public IEnumerable<int> SuccessExitCodes
         {
-            get => _validExitCodes;
+            get => _successExitCodes;
 
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException($"Assigned a null collection to {nameof(ValidExitCodes)}.");
+                    throw new ArgumentNullException($"Assigned a null collection to {nameof(SuccessExitCodes)}.");
                 if (value.Count() == 0)
-                    throw new InvalidOperationException($"Assigned an empty collection to {nameof(ValidExitCodes)}");
+                    throw new InvalidOperationException($"Assigned an empty collection to {nameof(SuccessExitCodes)}");
 
-                _validExitCodes = value.ToArray();
+                _successExitCodes = value.ToArray();
             }
         }
 
         private int _iterations;
-        private IEnumerable<int> _validExitCodes;
+        private IEnumerable<int> _successExitCodes;
     }
 }

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Xunit.Performance.Api
                     }
 
                     // Check for the exit code.
-                    if (!configuration.ValidExitCodes.Contains(process.ExitCode))
+                    if (!configuration.SuccessExitCodes.Contains(process.ExitCode))
                         throw new Exception($"'{processStartInfo.FileName}' exited with an invalid exit code: {process.ExitCode}");
                 }
 

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.3-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -16,6 +16,11 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\xunit.performance.api.xml</DocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>
@@ -37,11 +42,5 @@
     <ProjectReference Include="..\xunit.performance.execution\xunit.performance.execution.csproj" />
     <ProjectReference Include="..\xunit.performance.metrics\xunit.performance.metrics.csproj" />
   </ItemGroup>
-
-  <Target Name="PrePackage" BeforeTargets="BuildPackage">
-    <PropertyGroup>
-      <BuildCommand>$(BuildCommand) -IncludeReferencedProjects</BuildCommand>
-    </PropertyGroup>
-  </Target>
 
 </Project>

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.3-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/src/xunit.performance.core/xunit.performance.core.csproj
+++ b/src/xunit.performance.core/xunit.performance.core.csproj
@@ -15,6 +15,11 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\xunit.performance.core.xml</DocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -16,6 +16,11 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\xunit.performance.execution.xml</DocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -15,6 +15,11 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\xunit.performance.metrics.xml</DocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\common\GlobalAssemblyInfo.cs" Link="GlobalAssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Packing xml documentation of the API to enable intellisense information to end users
  (disable warning for missing documentation on public APIs)
- Fixed a bug on the ScenarioConfiguration where we were using `TimeSpam.Milliseconds` instead of `TimeSpam.TotalMilliseconds`
- Removed unused pre-package target from the xUnit Performance API csproj file