### PR TITLE
Fixing typo in attribute string

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0002
+  set VersionSuffix=beta-build0003
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
+++ b/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.Xunit.Performance.Api.PerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -15,7 +15,7 @@ namespace Microsoft.Xunit.Performance.Api
     {
         protected override bool Visit(IDiagnosticMessage diagnosticMessage)
         {
-            Console.Error.WriteLine(diagnosticMessage.Message);
+            WriteErrorLine(diagnosticMessage.Message);
             return true;
         }
     }

--- a/src/xunit.performance.core/OptimizeForBenchmarksAttribute.cs
+++ b/src/xunit.performance.core/OptimizeForBenchmarksAttribute.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Xunit.Performance
     /// <summary>
     /// Apply this attribute to an assembly if it contains benchmarks.  This attribute configures xUnit for benchmark execution.
     /// </summary>
-    [TestFrameworkDiscoverer("Microsoft.Xunit.Performance.BenchmarkTestFrameworkTypeDiscoverer", "xunit.performance.execution.{Platform}")]
+    [TestFrameworkDiscoverer("Microsoft.Xunit.Performance.BenchmarkTestFrameworkTypeDiscoverer", "xunit.performance.execution")]
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class OptimizeForBenchmarksAttribute : Attribute, ITestFrameworkAttribute
     {


### PR DESCRIPTION
- Unable to create custom test framework discoverer type 'xunit.performance.execution.{Platform}'