### PR TITLE
No need to reference xUnit NuGet package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Provides extensions over xUnit to author performance tests.
 ## Authoring benchmarks
 
 1. Create a new class library project
-2. Add a reference to the "xUnit" NuGet package
-3. Add a reference to the latest [xunit.performance.api.dll](https://dotnet.myget.org/feed/dotnet-core/package/nuget/xunit.performance.api)
-4. Add a reference to the latest [Microsoft.Diagnostics.Tracing.TraceEvent](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.Diagnostics.Tracing.TraceEvent)
+2. Add a reference to the latest [xunit.performance.api.dll](https://dotnet.myget.org/feed/dotnet-core/package/nuget/xunit.performance.api)
+3. Add a reference to the latest [Microsoft.Diagnostics.Tracing.TraceEvent](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.Diagnostics.Tracing.TraceEvent)
     (It deploys native libraries needed to merge the \*.etl files)
-5. Tag your test methods with [Benchmark] instead of [Fact]
-6. Make sure that each [Benchmark]-annotated test contains a loop of this form:
+4. Tag your test methods with [Benchmark] instead of [Fact]
+5. Make sure that each [Benchmark]-annotated test contains a loop of this form:
 
 ```csharp
 [Benchmark]


### PR DESCRIPTION
From the discussion with @jorive, this step is not needed anymore.

cc @joshfree 