### PR TITLE
Let's be friendly with locales using the comma "," as a decimal separator

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0004
+  set VersionSuffix=beta-build0005
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/CSVMetricReader.cs
+++ b/src/xunit.performance.api/CSVMetricReader.cs
@@ -4,6 +4,7 @@
 using Microsoft.Xunit.Performance.Sdk;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -25,7 +26,7 @@ namespace Microsoft.Xunit.Performance.Api
                     {
                         var line = sr.ReadLine();
                         var parts = line.Split(',');
-                        var timestamp = double.Parse(parts[0]);
+                        var timestamp = double.Parse(parts[0], CultureInfo.InvariantCulture);
                         var benchmarkName = parts[1].Replace(@"\_", ",").Replace(@"\n", "\n").Replace(@"\r", "\r").Replace(@"\\", @"\");
                         var eventName = parts[2];
                         switch (eventName)

--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xunit.Performance.Sdk;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -340,7 +341,7 @@ namespace Microsoft.Xunit.Performance.Api
                 ++index;
                 foreach (var kvp in iterationModel.Iteration)
                 {
-                    writer.WriteAttributeString(kvp.Key, kvp.Value.ToString());
+                    writer.WriteAttributeString(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
                 }
                 writer.WriteEndElement();
             }

--- a/src/xunit.performance.execution/BenchmarkEventSource.cs
+++ b/src/xunit.performance.execution/BenchmarkEventSource.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Xunit.Performance
             bool? success = null)
         {
             // TODO: this is going to add a lot of overhead; it's just here to get us running while we wait for an ETW-equivalent on Linux.
-            s_csvWriter.WriteLine($"{GetTimestamp()},{Escape(benchmarkName)},{eventName},{iteration?.ToString(CultureInfo.InvariantCulture) ?? ""},{success?.ToString() ?? ""},{stopReason}");
+            s_csvWriter.WriteLine($"{GetTimestamp().ToString(CultureInfo.InvariantCulture)},{Escape(benchmarkName)},{eventName},{iteration?.ToString(CultureInfo.InvariantCulture) ?? ""},{success?.ToString() ?? ""},{stopReason}");
         }
 
         [Event(1, Level = EventLevel.LogAlways, Opcode = EventOpcode.Start, Task = Tasks.Benchmark)]


### PR DESCRIPTION
Running the current `simpleharness` test project on a French system throws the following exception.

```
Unhandled Exception: System.Exception: Found unknown event:  "simpleharness.EmptyBenchmarkTest.Implementation_1", on "20170509124650.csv"
```

This PR attempts at fixing this issue.

Second commit just tweaks the xml serializer to make it generate a more XML friendly representation of a float. Would you feel this addition is unneeded, I'd be happy to drop it.