### PR TITLE
Removing virtual getter for Benchmark.InnerIterationCount.

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0006
+  set VersionSuffix=beta-build0007
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/src/xunit.performance.core/BenchmarkIterator.cs
+++ b/src/xunit.performance.core/BenchmarkIterator.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Xunit.Performance.Internal
     {
         internal static BenchmarkIterator Current { get; private set; }
 
+        protected BenchmarkIterator(long innerIterations)
+        {
+            InnerIterationCount = innerIterations;
+        }
+
         private static SemaphoreSlim s_semaphore = new SemaphoreSlim(1);
 
         /// <summary>
@@ -54,7 +59,7 @@ namespace Microsoft.Xunit.Performance.Internal
         /// <summary>
         /// Gets the inner iteration count for the current benchmark
         /// </summary>
-        protected internal abstract long InnerIterationCount { get; }
+        internal long InnerIterationCount { get; }
 
         /// <summary>
         /// Starts measurement for the given iteration, if it is the current iteration.


### PR DESCRIPTION
- Solving issue: https://github.com/Microsoft/xunit-performance/issues/230