### PR TITLE
Avoid calling StopMeasurement twice.

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0007
+  set VersionSuffix=beta-build0008
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/build.cmd
+++ b/build.cmd
@@ -84,12 +84,12 @@ setlocal
 
 :dotnet_pack
 setlocal
+  call :dotnet_build || exit /b 1
+
   echo/
   echo/  ==========
   echo/   Packing %cd%
   echo/  ==========
-  call :dotnet_build || exit /b 1
-
   set MsBuildArgs=
   set "MsBuildArgs=%MsBuildArgs% --no-build"
   set "MsBuildArgs=%MsBuildArgs% -c %BuildConfiguration%"

--- a/global.json
+++ b/global.json
@@ -1,3 +1,0 @@
-{
-    "projects": [ "src" ]
-}

--- a/src/xunit.performance.api/Profilers/ETWProfiler.cs
+++ b/src/xunit.performance.api/Profilers/ETWProfiler.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Xunit.Performance.Api
         /// <param name="xUnitPerformanceSessionData"></param>
         /// <param name="xUnitPerformanceMetricData"></param>
         /// <param name="action"></param>
-        /// <returns></returns>
         public static void Record(XUnitPerformanceSessionData xUnitPerformanceSessionData, XUnitPerformanceMetricData xUnitPerformanceMetricData, Action action)
         {
             const int bufferSizeMB = 256;
@@ -55,6 +54,8 @@ namespace Microsoft.Xunit.Performance.Api
                 WriteErrorLine(message);
                 throw new InvalidOperationException(message);
             }
+
+            WriteDebugLine("> ETW capture start.");
 
             using (var safeKernelSession = needKernelSession && CanEnableEnableKernelProvider ? MakeSafeTerminateTraceEventSession(KernelTraceEventParser.KernelSessionName, etwOutputData.KernelFileName) : null)
             {
@@ -87,10 +88,14 @@ namespace Microsoft.Xunit.Performance.Api
                 }
             }
 
+            WriteDebugLine("> ETW capture stop.");
+
             // TODO: Decouple the code below.
             // Collect ETW profile data.
             //  TODO: Skip collecting kernel data if it was not captured! (data will be zero, there is no point to report it or upload it)
+            WriteDebugLine("> ETW merge start.");
             TraceEventSession.MergeInPlace(etwOutputData.UserFileName, Console.Out);
+            WriteDebugLine("> ETW merge stop.");
             xUnitPerformanceSessionData.CollectOutputFilesCallback(etwOutputData.UserFileName);
 
             var assemblyModel = GetAssemblyModel(xUnitPerformanceSessionData.AssemblyFileName, etwOutputData.UserFileName, xUnitPerformanceSessionData.RunId, xUnitPerformanceMetricData.PerformanceTestMessages);

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -162,6 +162,12 @@ namespace Microsoft.Xunit.Performance.Api
 
         private void ProcessResults(XUnitPerformanceSessionData xUnitSessionData, XUnitPerformanceMetricData xUnitPerformanceMetricData)
         {
+            if (!File.Exists(Configuration.FileLogPath))
+            {
+                WriteWarningLine($"Results file '{Configuration.FileLogPath}' does not exist. Skipping processing of results.");
+                return;
+            }
+
             var reader = new CSVMetricReader(Configuration.FileLogPath);
             var fileNameWithoutExtension = $"{xUnitSessionData.RunId}-{Path.GetFileNameWithoutExtension(xUnitSessionData.AssemblyFileName)}";
 

--- a/src/xunit.performance.core/BenchmarkIterationMeasurement.cs
+++ b/src/xunit.performance.core/BenchmarkIterationMeasurement.cs
@@ -11,15 +11,30 @@ namespace Microsoft.Xunit.Performance
 
         internal BenchmarkIterationMeasurement(BenchmarkIteration iteration)
         {
+            _disposedValue = false;
             _iteration = iteration;
         }
 
-        /// <summary>
-        /// Completes measurement of this iteration.
-        /// </summary>
+        #region IDisposable Support
+        private bool _disposedValue;
+
+        void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    // Completes measurement of this iteration.
+                    _iteration.StopMeasurement();
+                }
+                _disposedValue = true;
+            }
+        }
+
         public void Dispose()
         {
-            _iteration.StopMeasurement();
+            Dispose(true);
         }
+        #endregion
     }
 }

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingLibraryVersion)" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/simpleharness/EndToEndTests.cs
+++ b/tests/simpleharness/EndToEndTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Xunit.Performance;
+
+namespace simpleharness
+{
+    public static class EndToEndTests
+    {
+        [Benchmark(InnerIterationCount = 10000)]
+        public static void BenchmarkIterationMeasurementDoubleDispose()
+        {
+            foreach (BenchmarkIteration iter in Benchmark.Iterations)
+            {
+                {
+                    var benchmarkIterationMeasurement = iter.StartMeasurement();
+                    try
+                    {
+                        for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        {
+                            s_formatterString = string.Format("{0}{1}{2}{3}", "a", "b", "c", "d");
+                        }
+                    }
+                    finally
+                    {
+                        benchmarkIterationMeasurement.Dispose();
+                        benchmarkIterationMeasurement.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static volatile string s_formatterString;
+    }
+}


### PR DESCRIPTION
- Remove unnecessary package reference
- Remove global.json file
- Skip attempt to process csv file when there is no file (Benchmarks did not run. For example, they are all facts or disabled)
  (We throw `System.IO.FileNotFoundException` exception when no benchmark ran.)
- Print more Debug information on the ETW profiling.