### PR TITLE
Add more capabilities to scenario tests

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0010
+  set VersionSuffix=beta-build0011
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/build.cmd
+++ b/build.cmd
@@ -27,6 +27,7 @@ setlocal enabledelayedexpansion
   set procedures=%procedures% build_xunit_performance_metrics
   set procedures=%procedures% build_xunit_performance_api
   set procedures=%procedures% build_tests_simpleharness
+  set procedures=%procedures% build_tests_scenariobenchmark
 
   for %%p in (%procedures%) do (
     call :%%p || (
@@ -72,6 +73,22 @@ setlocal
   for %%v in (1.0 1.1 2.0) do (
     dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                || exit /b 1
     dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\simpleharness.dll" --perf:collect default+gcapi  || exit /b 1
+  )
+
+  exit /b %errorlevel%
+
+:build_tests_scenariobenchmark
+setlocal
+  cd /d %~dp0tests\scenariobenchmark
+  call :dotnet_build || exit /b 1
+  net.exe session 1>nul 2>&1 || (
+    call :print_error_message Cannot run scenariobenchmark test because this is not an administrator window
+    exit /b 1
+  )
+
+  for %%v in (1.0 1.1 2.0) do (
+    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                || exit /b 1
+    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\scenariobenchmark.dll" --perf:collect default    || exit /b 1
   )
 
   exit /b %errorlevel%

--- a/build.cmd
+++ b/build.cmd
@@ -13,6 +13,9 @@ setlocal enabledelayedexpansion
   set OutputDirectory=%~dp0LocalPackages
   call :remove_directory "%OutputDirectory%" || exit /b 1
 
+  rem Don't fall back to machine-installed versions of dotnet, only use repo-local version
+  set DOTNET_MULTILEVEL_LOOKUP=0
+
   call "%~dp0.\dotnet-install.cmd" || exit /b 1
 
   echo Where is dotnet.exe?

--- a/src/xunit.performance.api/MarkdownHelper.cs
+++ b/src/xunit.performance.api/MarkdownHelper.cs
@@ -1,6 +1,7 @@
 ﻿using MarkdownLog;
 using Microsoft.Xunit.Performance.Api.Table;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -42,14 +43,49 @@ namespace Microsoft.Xunit.Performance.Api
 
         public static MarkdownLog.Table GenerateMarkdownTable(DataTable dt)
         {
-            var rows = dt.ColumnNames.Count() > 0 ?
-                dt.Rows.OrderBy(columns => columns[dt.ColumnNames.First()]) :
-                dt.Rows;
+            bool includesScenarioNameColumn = false;
+            if (dt.ColumnNames.Count() > 0 && dt.ColumnNames.First().Name == TableHeader.ScenarioName)
+            {
+                includesScenarioNameColumn = true;
+            }
+            IEnumerable<Row> rows;
+            if (includesScenarioNameColumn)
+            {
+                rows = dt.Rows.OrderBy(columns => columns[dt.ColumnNames[TableHeader.ScenarioName]])
+                              .ThenBy(columns => columns[dt.ColumnNames[TableHeader.TestName]]);
+            }
+            else if (dt.ColumnNames.Count() > 0)
+            {
+                rows = dt.Rows.OrderBy(columns => columns[dt.ColumnNames.First()]);
+            }
+            else
+            {
+                rows = dt.Rows;
+            }
 
-            var cellValueFunctions = new Func<Row, object>[] {
-                (row) => {
+            var cellValueFunctions = new List<Func<Row, object>>();
+
+            if (includesScenarioNameColumn)
+            {
+                cellValueFunctions.Add((row) =>
+                {
+                    return row[dt.ColumnNames[TableHeader.ScenarioName]];
+                });
+                cellValueFunctions.Add((row) =>
+                {
+                    return row[dt.ColumnNames[TableHeader.TestName]];
+                });
+            }
+            else
+            {
+                cellValueFunctions.Add((row) =>
+                {
                     return row[dt.ColumnNames[dt.ColumnNames.First().Name]];
-                },
+                });
+            }
+
+            cellValueFunctions.AddRange(new Func<Row, object>[]
+            {
                 (row) => {
                     return row[dt.ColumnNames[TableHeader.Metric]];
                 },
@@ -71,17 +107,23 @@ namespace Microsoft.Xunit.Performance.Api
                 (row) => {
                     return ConvertToDoubleFormattedString(row[dt.ColumnNames[TableHeader.Maximum]]);
                 },
-            };
+            });
 
-            var mdTable = rows.ToMarkdownTable(cellValueFunctions);
-            mdTable.Columns = from column in dt.ColumnNames
-                              select new TableColumn
-                              {
-                                  HeaderCell = new TableCell() { Text = column.Name }
-                              };
-            mdTable.Columns = new TableColumn[]
+            var mdTable = rows.ToMarkdownTable(cellValueFunctions.ToArray());
+
+            List<TableColumn> tableColumns = new List<TableColumn>();
+            if (includesScenarioNameColumn)
             {
-                new TableColumn(){ HeaderCell = new TableCell() { Text = dt.ColumnNames.First().Name }, Alignment = TableColumnAlignment.Left },
+                tableColumns.Add(new TableColumn() { HeaderCell = new TableCell() { Text = TableHeader.ScenarioName }, Alignment = TableColumnAlignment.Left });
+                tableColumns.Add(new TableColumn() { HeaderCell = new TableCell() { Text = TableHeader.TestName }, Alignment = TableColumnAlignment.Left });
+            }
+            else
+            {
+                tableColumns.Add(new TableColumn() { HeaderCell = new TableCell() { Text = dt.ColumnNames.First().Name }, Alignment = TableColumnAlignment.Left });
+            }
+
+            tableColumns.AddRange(new TableColumn[]
+            {
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.Metric }, Alignment = TableColumnAlignment.Left },
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.Unit }, Alignment = TableColumnAlignment.Center },
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.Iterations }, Alignment = TableColumnAlignment.Center },
@@ -89,7 +131,9 @@ namespace Microsoft.Xunit.Performance.Api
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.StandardDeviation }, Alignment = TableColumnAlignment.Right },
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.Minimum }, Alignment = TableColumnAlignment.Right },
                 new TableColumn(){ HeaderCell = new TableCell() { Text = TableHeader.Maximum }, Alignment = TableColumnAlignment.Right },
-            };
+            });
+
+            mdTable.Columns = tableColumns;
             return mdTable;
         }
 

--- a/src/xunit.performance.api/MarkdownHelper.cs
+++ b/src/xunit.performance.api/MarkdownHelper.cs
@@ -139,10 +139,10 @@ namespace Microsoft.Xunit.Performance.Api
 
         private static string ConvertToDoubleFormattedString(string data)
         {
-            const string fixedFotmat = "F3";
+            const string fixedFormat = "F3";
             const string scientificNotationFormat = "E3";
             var d = Convert.ToDouble(data);
-            var format = (d != 0 && (d > 99999 || Math.Abs(d) < 0.001)) ? scientificNotationFormat : fixedFotmat;
+            var format = (d != 0 && (d > 999999 || Math.Abs(d) < 0.001)) ? scientificNotationFormat : fixedFormat;
             return d.ToString(format, CultureInfo.InvariantCulture);
         }
     }

--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Xunit.Performance.Api
         }
     }
 
-    public sealed class ScenarioTestResultRow
+    internal sealed class ScenarioTestResultRow
     {
         public string ScenarioName { get; set; }
         public string TestName { get; set; }

--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -222,17 +222,66 @@ namespace Microsoft.Xunit.Performance.Api
             }
         }
 
-        internal DataTable GetStatistics()
+        internal static DataTable GetEmptyTable(string scenarioName = null)
         {
             var dt = new DataTable();
-            var col0_testName = dt.AddColumn(Name);
-            var col1_metric = dt.AddColumn(TableHeader.Metric);
-            var col2_unit = dt.AddColumn(TableHeader.Unit);
-            var col3_iterations = dt.AddColumn(TableHeader.Iterations);
-            var col4_average = dt.AddColumn(TableHeader.Average);
-            var col5_stdevs = dt.AddColumn(TableHeader.StandardDeviation);
-            var col6_min = dt.AddColumn(TableHeader.Minimum);
-            var col7_max = dt.AddColumn(TableHeader.Maximum);
+            if (scenarioName == null)
+            {
+                dt.AddColumn(TableHeader.ScenarioName);
+                dt.AddColumn(TableHeader.TestName);
+            }
+            else
+            {
+                dt.AddColumn(scenarioName);
+            }
+            dt.AddColumn(TableHeader.Metric);
+            dt.AddColumn(TableHeader.Unit);
+            dt.AddColumn(TableHeader.Iterations);
+            dt.AddColumn(TableHeader.Average);
+            dt.AddColumn(TableHeader.StandardDeviation);
+            dt.AddColumn(TableHeader.Minimum);
+            dt.AddColumn(TableHeader.Maximum);
+
+            return dt;
+        }
+
+        internal DataTable GetStatisticsTable(bool includeScenarioNameColumn = false)
+        {
+            var dt = GetEmptyTable(includeScenarioNameColumn ? null : Name);
+
+            AddRowsToTable(dt, GetStatistics(), includeScenarioNameColumn);
+
+            return dt;
+        }
+
+        internal void AddRowsToTable(DataTable dt, IEnumerable<ScenarioTestResultRow> rows, bool includeScenarioNameColumn = false)
+        {
+            foreach (var row in rows)
+            {
+                var newRow = dt.AppendRow();
+                if (includeScenarioNameColumn)
+                {
+                    newRow[dt.ColumnNames[TableHeader.ScenarioName]] = row.ScenarioName;
+                    newRow[dt.ColumnNames[TableHeader.TestName]] = row.TestName;
+                }
+                else
+                {
+                    newRow[dt.ColumnNames[row.ScenarioName]] = row.TestName;
+                }
+                newRow[dt.ColumnNames[TableHeader.Metric]] = row.MetricName;
+                newRow[dt.ColumnNames[TableHeader.Unit]] = row.MetricUnit;
+
+                newRow[dt.ColumnNames[TableHeader.Iterations]] = row.Iterations.ToString();
+                newRow[dt.ColumnNames[TableHeader.Average]] = row.Average.ToString();
+                newRow[dt.ColumnNames[TableHeader.StandardDeviation]] = row.StandardDeviation.ToString();
+                newRow[dt.ColumnNames[TableHeader.Minimum]] = row.Minimum.ToString();
+                newRow[dt.ColumnNames[TableHeader.Maximum]] = row.Maximum.ToString();
+            }
+        }
+
+        internal List<ScenarioTestResultRow> GetStatistics()
+        {
+            List<ScenarioTestResultRow> ret = new List<ScenarioTestResultRow>();
 
             foreach (var test in Tests)
             {
@@ -254,22 +303,38 @@ namespace Microsoft.Xunit.Performance.Api
                     var max = values.Max();
                     var min = values.Min();
 
-                    var newRow = dt.AppendRow();
-                    newRow[col0_testName] = string.IsNullOrEmpty(test.Namespace) ?
+                    ScenarioTestResultRow row = new ScenarioTestResultRow();
+                    row.ScenarioName = Name;
+                    row.TestName = string.IsNullOrEmpty(test.Namespace) ?
                         $"{test.Name}" : $"{test.Namespace}{test.Separator}{test.Name}";
-                    newRow[col1_metric] = metric.DisplayName;
-                    newRow[col2_unit] = metric.Unit;
+                    row.MetricName = metric.DisplayName;
+                    row.MetricUnit = metric.Unit;
 
-                    newRow[col3_iterations] = values.Count().ToString();
-                    newRow[col4_average] = avg.ToString();
-                    newRow[col5_stdevs] = stdev_s.ToString();
-                    newRow[col6_min] = min.ToString();
-                    newRow[col7_max] = max.ToString();
+                    row.Iterations = values.Count();
+                    row.Average = avg;
+                    row.StandardDeviation = stdev_s;
+                    row.Minimum = min;
+                    row.Maximum = max;
+
+                    ret.Add(row);
                 }
             }
 
-            return dt;
+            return ret;
         }
+    }
+
+    public sealed class ScenarioTestResultRow
+    {
+        public string ScenarioName { get; set; }
+        public string TestName { get; set; }
+        public string MetricName { get; set; }
+        public string MetricUnit { get; set; }
+        public int Iterations { get; set; }
+        public double Average { get; set; }
+        public double StandardDeviation { get; set; }
+        public double Minimum { get; set; }
+        public double Maximum { get; set; }
     }
 
     [Serializable]

--- a/src/xunit.performance.api/Model/TableHeader.cs
+++ b/src/xunit.performance.api/Model/TableHeader.cs
@@ -2,6 +2,7 @@ namespace Microsoft.Xunit.Performance.Api
 {
     internal static class TableHeader
     {
+        public static string ScenarioName => "Scenario Name";
         public static string TestName => "Test Name";
 
         public static string Metric => "Metric";

--- a/src/xunit.performance.api/ScenarioConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioConfiguration.cs
@@ -85,6 +85,8 @@ namespace Microsoft.Xunit.Performance.Api
         /// </summary>
         public Action<ScenarioExecutionResult> PostIterationDelegate { get; set; }
 
+        public string TestName { get; set; }
+
         private int _iterations;
         private IEnumerable<int> _successExitCodes;
     }

--- a/src/xunit.performance.api/ScenarioExecutionResult.cs
+++ b/src/xunit.performance.api/ScenarioExecutionResult.cs
@@ -16,15 +16,19 @@ namespace Microsoft.Xunit.Performance.Api
         /// Initializes a new instance of the ScenarioExecutionResult class.
         /// </summary>
         /// <param name="process">Scenario benchmark process that was run.</param>
-        public ScenarioExecutionResult(System.Diagnostics.Process process)
+        /// <param name="configuration">Configuration for the scenario that was run.</param>
+        public ScenarioExecutionResult(System.Diagnostics.Process process, ScenarioTestConfiguration configuration)
         {
             ProcessExitInfo = new ProcessExitInfo(process);
+            Configuration = configuration;
         }
 
         /// <summary>
         /// State of the run scenario process.
         /// </summary>
         public ProcessExitInfo ProcessExitInfo { get; }
+
+        public ScenarioTestConfiguration Configuration { get; }
 
         /// <summary>
         /// Binary .etl file name where the ETW traces were logged.

--- a/src/xunit.performance.api/ScenarioExecutionResult.cs
+++ b/src/xunit.performance.api/ScenarioExecutionResult.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Xunit.Performance.Api
         /// </summary>
         public ProcessExitInfo ProcessExitInfo { get; }
 
+        /// <summary>
+        /// Configuration for the scenario that was run
+        /// </summary>
         public ScenarioTestConfiguration Configuration { get; }
 
         /// <summary>

--- a/src/xunit.performance.api/ScenarioTest.cs
+++ b/src/xunit.performance.api/ScenarioTest.cs
@@ -3,9 +3,9 @@ using System.Diagnostics;
 
 namespace Microsoft.Xunit.Performance.Api
 {
-    public sealed class Scenario : IDisposable
+    public sealed class ScenarioTest : IDisposable
     {
-        public Scenario(ScenarioConfiguration configuration)
+        public ScenarioTest(ScenarioTestConfiguration configuration)
         {
             _disposedValue = false;
             Process = new Process {

--- a/src/xunit.performance.api/ScenarioTest.cs
+++ b/src/xunit.performance.api/ScenarioTest.cs
@@ -3,8 +3,15 @@ using System.Diagnostics;
 
 namespace Microsoft.Xunit.Performance.Api
 {
+    /// <summary>
+    /// Represents a scenario test that is about to be run
+    /// </summary>
     public sealed class ScenarioTest : IDisposable
     {
+        /// <summary>
+        /// Creates a new <see cref="ScenarioTest"/> object
+        /// </summary>
+        /// <param name="configuration">The scenario configuration</param>
         public ScenarioTest(ScenarioTestConfiguration configuration)
         {
             _disposedValue = false;
@@ -13,6 +20,9 @@ namespace Microsoft.Xunit.Performance.Api
             };
         }
 
+        /// <summary>
+        /// The process that will be run for the test
+        /// </summary>
         public Process Process { get; }
 
         #region IDisposable Support

--- a/src/xunit.performance.api/ScenarioTestConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioTestConfiguration.cs
@@ -85,11 +85,20 @@ namespace Microsoft.Xunit.Performance.Api
         /// </summary>
         public Action<ScenarioExecutionResult> PostIterationDelegate { get; set; }
 
+        /// <summary>
+        /// The name of the test
+        /// </summary>
         public string TestName { get; set; }
 
+        /// <summary>
+        /// The scenario to which this test belongs
+        /// </summary>
         public ScenarioBenchmark Scenario { get; set; }
 
-        public bool SaveResults { get; set; }
+        /// <summary>
+        /// Indicates whether the results from the test should be saved after it is run
+        /// </summary>
+        public bool SaveResults { get; set; } = true;
 
 
         private int _iterations;

--- a/src/xunit.performance.api/ScenarioTestConfiguration.cs
+++ b/src/xunit.performance.api/ScenarioTestConfiguration.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Xunit.Performance.Api
     /// <summary>
     /// Provides an interface to configure how benchmark scenarios are run by the XunitPerformanceHarness.
     /// </summary>
-    public sealed class ScenarioConfiguration
+    public sealed class ScenarioTestConfiguration
     {
         /// <summary>
         /// Initializes a new instance of the ScenarioConfiguration class.
         /// </summary>
         /// <param name="timeSpan">The amount of time to wait for one iteration process to exit.</param>
         /// <param name="startInfo">The data with which to start the scenario.</param>
-        public ScenarioConfiguration(TimeSpan timeSpan, ProcessStartInfo startInfo)
+        public ScenarioTestConfiguration(TimeSpan timeSpan, ProcessStartInfo startInfo)
         {
             if (timeSpan.TotalMilliseconds < 1)
                 throw new InvalidOperationException("The time out per iteration must be a positive number.");
@@ -78,7 +78,7 @@ namespace Microsoft.Xunit.Performance.Api
         /// <summary>
         /// The action that will be executed before every benchmark scenario execution.
         /// </summary>
-        public Action<Scenario> PreIterationDelegate { get; set; }
+        public Action<ScenarioTest> PreIterationDelegate { get; set; }
 
         /// <summary>
         /// The action that will be executed after every benchmark scenario execution.
@@ -86,6 +86,11 @@ namespace Microsoft.Xunit.Performance.Api
         public Action<ScenarioExecutionResult> PostIterationDelegate { get; set; }
 
         public string TestName { get; set; }
+
+        public ScenarioBenchmark Scenario { get; set; }
+
+        public bool SaveResults { get; set; }
+
 
         private int _iterations;
         private IEnumerable<int> _successExitCodes;

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Xunit.Performance.Api
                 WriteInfoLine($"File saved to: \"{fileName}\"");
             };
 
-            var scenarioFileName = $"{Configuration.RunId}-{Path.GetFileNameWithoutExtension(configuration.StartInfo.FileName)}";
+            var scenarioFileName = $"{Configuration.RunId}-{configuration.TestName ?? Path.GetFileNameWithoutExtension(configuration.StartInfo.FileName)}";
+            var fileNameWithoutExtension = Path.Combine(OutputDirectory, $"{scenarioFileName}");
 
             for (int i = 0; i < configuration.Iterations; ++i)
             {
@@ -114,7 +115,14 @@ namespace Microsoft.Xunit.Performance.Api
                     if (IsWindowsPlatform && _requireEtw)
                     {
                         var sessionName = $"Performance-Api-Session-{Configuration.RunId}";
-                        var etlFileName = $"{Path.Combine(OutputDirectory, $"{scenarioFileName}")}({i}).etl";
+
+                        string tracesFolder = Path.Combine(OutputDirectory, $"{fileNameWithoutExtension}-traces");
+                        if (!Directory.Exists(tracesFolder))
+                        {
+                            Directory.CreateDirectory(tracesFolder);
+                        }
+
+                        var etlFileName = Path.Combine(tracesFolder, $"{scenarioFileName}({i}).etl");
 
                         var userSpecifiedMetrics = _metricCollectionFactory.GetMetrics();
                         var kernelProviders = userSpecifiedMetrics

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -78,6 +78,10 @@ namespace Microsoft.Xunit.Performance.Api
             }
         }
 
+        Action<string> OutputFileCallback = (fileName) => {
+            WriteInfoLine($"File saved to: \"{fileName}\"");
+        };
+
         /// <summary>
         /// Executes the benchmark scenario specified by the parameter
         /// containing the process start information.<br/>
@@ -88,29 +92,47 @@ namespace Microsoft.Xunit.Performance.Api
         /// </summary>
         /// <param name="configuration">ScenarioConfiguration object that defined the scenario execution.</param>
         /// <param name="teardownDelegate">The action that will be executed after running all benchmark scenario iterations.</param>
-        public void RunScenario(ScenarioConfiguration configuration, Func<ScenarioBenchmark> teardownDelegate)
+        public void RunScenario(ScenarioTestConfiguration configuration, Action<ScenarioBenchmark> teardownDelegate)
         {
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
             if (teardownDelegate == null)
                 throw new ArgumentNullException(nameof(teardownDelegate));
 
-            Action<string> OutputFileCallback = (fileName) => {
-                WriteInfoLine($"File saved to: \"{fileName}\"");
-            };
+            string testName;
+            if (configuration.TestName == null)
+            {
+                testName = Path.GetFileNameWithoutExtension(configuration.StartInfo.FileName);
+                if (configuration.Scenario == null)
+                {
+                    configuration.Scenario = new ScenarioBenchmark(testName);
+                }
+            }
+            else
+            {
+                if (configuration.Scenario == null)
+                {
+                    testName = configuration.TestName;
+                    configuration.Scenario = new ScenarioBenchmark(testName);
+                }
+                else
+                {
+                    testName = configuration.Scenario.Name + " - " + configuration.TestName;
+                }
+            }
 
-            var scenarioFileName = $"{Configuration.RunId}-{configuration.TestName ?? Path.GetFileNameWithoutExtension(configuration.StartInfo.FileName)}";
+            var scenarioFileName = $"{Configuration.RunId}-{testName}";
             var fileNameWithoutExtension = Path.Combine(OutputDirectory, $"{scenarioFileName}");
 
             for (int i = 0; i < configuration.Iterations; ++i)
             {
-                using (var scenario = new Scenario(configuration))
+                using (var scenarioTest = new ScenarioTest(configuration))
                 {
                     ScenarioExecutionResult scenarioExecutionResult;
 
-                    configuration.PreIterationDelegate?.Invoke(scenario);
+                    configuration.PreIterationDelegate?.Invoke(scenarioTest);
 
-                    WriteInfoLine($"$ {Path.GetFileName(scenario.Process.StartInfo.FileName)} {scenario.Process.StartInfo.Arguments}");
+                    WriteInfoLine($"$ {Path.GetFileName(scenarioTest.Process.StartInfo.FileName)} {scenarioTest.Process.StartInfo.Arguments}");
 
                     if (IsWindowsPlatform && _requireEtw)
                     {
@@ -154,7 +176,7 @@ namespace Microsoft.Xunit.Performance.Api
                             UserProvider.Defaults,
                             kernelProviders.ToList());
 
-                        scenarioExecutionResult = listener.Record(() => { return Run(configuration, scenario); });
+                        scenarioExecutionResult = listener.Record(() => { return Run(configuration, scenarioTest); });
 
                         scenarioExecutionResult.EventLogFileName = etlFileName;
                         scenarioExecutionResult.PerformanceMonitorCounters = userSpecifiedMetrics
@@ -169,31 +191,51 @@ namespace Microsoft.Xunit.Performance.Api
                     }
                     else
                     {
-                        scenarioExecutionResult = Run(configuration, scenario);
+                        scenarioExecutionResult = Run(configuration, scenarioTest);
                     }
 
                     configuration.PostIterationDelegate?.Invoke(scenarioExecutionResult);
                 }
             }
 
-            ScenarioBenchmark scenarioBenchmark = teardownDelegate();
-            if (scenarioBenchmark == null)
-                throw new InvalidOperationException("The Teardown Delegate should return a valid instance of ScenarioBenchmark.");
+            teardownDelegate(configuration.Scenario);
 
-            var scenarioBenchmarkFileNameWithoutExtension = Path.Combine(OutputDirectory, $"{Configuration.RunId}-{scenarioBenchmark.Name}");
+            if (configuration.SaveResults)
+            {
+                WriteResults(configuration.Scenario, fileNameWithoutExtension);
+            }
+        }
 
-            var xmlFileName = $"{scenarioBenchmarkFileNameWithoutExtension}.xml";
-            scenarioBenchmark.Serialize(xmlFileName);
+        public void WriteResults(ScenarioBenchmark scenario, string fileNameWithoutExtension)
+        {
+            WriteXmlResults(scenario, fileNameWithoutExtension);
+
+            WriteTableResults(new[] { scenario }, fileNameWithoutExtension, false);
+        }
+
+        public void WriteXmlResults(ScenarioBenchmark scenario, string fileNameWithoutExtension)
+        {
+            var xmlFileName = $"{fileNameWithoutExtension}.xml";
+            scenario.Serialize(xmlFileName);
             OutputFileCallback?.Invoke(xmlFileName);
+        }
 
-            var dt = scenarioBenchmark.GetStatistics();
+        public void WriteTableResults(IEnumerable<ScenarioBenchmark> scenarios, string fileNameWithoutExtension, bool includeScenarioNameColumn)
+        {
+            var dt = ScenarioBenchmark.GetEmptyTable(includeScenarioNameColumn ? null : scenarios.First().Name);
+
+            foreach (var scenario in scenarios)
+            {
+                scenario.AddRowsToTable(dt, scenario.GetStatistics(), includeScenarioNameColumn);
+            }
+
             var mdTable = MarkdownHelper.GenerateMarkdownTable(dt);
 
-            var csvFileName = $"{scenarioBenchmarkFileNameWithoutExtension}.csv";
+            var csvFileName = $"{fileNameWithoutExtension}.csv";
             dt.WriteToCSV(csvFileName);
             OutputFileCallback?.Invoke(csvFileName);
 
-            var mdFileName = $"{scenarioBenchmarkFileNameWithoutExtension}.md";
+            var mdFileName = $"{fileNameWithoutExtension}.md";
             MarkdownHelper.Write(mdFileName, mdTable);
             OutputFileCallback?.Invoke(mdFileName);
             Console.WriteLine(MarkdownHelper.ToTrimmedTable(mdTable));
@@ -204,30 +246,30 @@ namespace Microsoft.Xunit.Performance.Api
             return XunitPerformanceHarnessOptions.Usage();
         }
 
-        private static ScenarioExecutionResult Run(ScenarioConfiguration configuration, Scenario scenario)
+        private static ScenarioExecutionResult Run(ScenarioTestConfiguration configuration, ScenarioTest scenarioTest)
         {
-            if (!scenario.Process.Start())
-                throw new Exception($"Failed to start {scenario.Process.ProcessName}");
+            if (!scenarioTest.Process.Start())
+                throw new Exception($"Failed to start {scenarioTest.Process.ProcessName}");
 
-            if (scenario.Process.StartInfo.RedirectStandardError)
-                scenario.Process.BeginErrorReadLine();
-            if (scenario.Process.StartInfo.RedirectStandardInput)
+            if (scenarioTest.Process.StartInfo.RedirectStandardError)
+                scenarioTest.Process.BeginErrorReadLine();
+            if (scenarioTest.Process.StartInfo.RedirectStandardInput)
                 throw new NotSupportedException($"RedirectStandardInput is not currently supported.");
-            if (scenario.Process.StartInfo.RedirectStandardOutput)
-                scenario.Process.BeginOutputReadLine();
+            if (scenarioTest.Process.StartInfo.RedirectStandardOutput)
+                scenarioTest.Process.BeginOutputReadLine();
 
-            if (scenario.Process.WaitForExit((int)(configuration.TimeoutPerIteration.TotalMilliseconds)) == false)
+            if (scenarioTest.Process.WaitForExit((int)(configuration.TimeoutPerIteration.TotalMilliseconds)) == false)
             {
                 // TODO: scenarioOutput.Process.Kill[All|Tree]();
-                scenario.Process.Kill();
+                scenarioTest.Process.Kill();
                 throw new TimeoutException("Running benchmark scenario has timed out.");
             }
 
             // Check for the exit code.
-            if (!configuration.SuccessExitCodes.Contains(scenario.Process.ExitCode))
-                throw new Exception($"'{scenario.Process.StartInfo.FileName}' exited with an invalid exit code: {scenario.Process.ExitCode}");
+            if (!configuration.SuccessExitCodes.Contains(scenarioTest.Process.ExitCode))
+                throw new Exception($"'{scenarioTest.Process.StartInfo.FileName}' exited with an invalid exit code: {scenarioTest.Process.ExitCode}");
 
-            return new ScenarioExecutionResult(scenario.Process);
+            return new ScenarioExecutionResult(scenarioTest.Process, configuration);
         }
 
         private void ProcessResults(XUnitPerformanceSessionData xUnitSessionData, XUnitPerformanceMetricData xUnitPerformanceMetricData)

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -78,9 +78,9 @@ namespace Microsoft.Xunit.Performance.Api
             }
         }
 
-        Action<string> OutputFileCallback = (fileName) => {
+        static void LogFileSaved(string fileName) {
             WriteInfoLine($"File saved to: \"{fileName}\"");
-        };
+        }
 
         /// <summary>
         /// Executes the benchmark scenario specified by the parameter
@@ -187,7 +187,7 @@ namespace Microsoft.Xunit.Performance.Api
                             })
                             .ToHashSet();
 
-                        OutputFileCallback?.Invoke(etlFileName);
+                        LogFileSaved(etlFileName);
                     }
                     else
                     {
@@ -206,6 +206,12 @@ namespace Microsoft.Xunit.Performance.Api
             }
         }
 
+        /// <summary>
+        /// Save results from an executed scenario
+        /// </summary>
+        /// <param name="scenario">The scenario to save results for</param>
+        /// <param name="fileNameWithoutExtension">The filename (without extension) to use to save results</param>
+        /// <remarks>This will save an XML, a Markdown, and a CSV file with the results.</remarks>
         public void WriteResults(ScenarioBenchmark scenario, string fileNameWithoutExtension)
         {
             WriteXmlResults(scenario, fileNameWithoutExtension);
@@ -213,13 +219,24 @@ namespace Microsoft.Xunit.Performance.Api
             WriteTableResults(new[] { scenario }, fileNameWithoutExtension, false);
         }
 
+        /// <summary>
+        /// Save results from an executed scenario in XML format
+        /// </summary>
+        /// <param name="scenario">The scenario to save results for</param>
+        /// <param name="fileNameWithoutExtension">The filename (without extension) to use to save results</param>
         public void WriteXmlResults(ScenarioBenchmark scenario, string fileNameWithoutExtension)
         {
             var xmlFileName = $"{fileNameWithoutExtension}.xml";
             scenario.Serialize(xmlFileName);
-            OutputFileCallback?.Invoke(xmlFileName);
+            LogFileSaved(xmlFileName);
         }
 
+        /// <summary>
+        /// Saves Markdown and CSV results for executed scenarios
+        /// </summary>
+        /// <param name="scenarios">The scenarios to save results for</param>
+        /// <param name="fileNameWithoutExtension">The filename (without extension) to use to save results</param>
+        /// <param name="includeScenarioNameColumn">Indicates whether scenario name should be included in the tables as the first column</param>
         public void WriteTableResults(IEnumerable<ScenarioBenchmark> scenarios, string fileNameWithoutExtension, bool includeScenarioNameColumn)
         {
             var dt = ScenarioBenchmark.GetEmptyTable(includeScenarioNameColumn ? null : scenarios.First().Name);
@@ -233,11 +250,11 @@ namespace Microsoft.Xunit.Performance.Api
 
             var csvFileName = $"{fileNameWithoutExtension}.csv";
             dt.WriteToCSV(csvFileName);
-            OutputFileCallback?.Invoke(csvFileName);
+            LogFileSaved(csvFileName);
 
             var mdFileName = $"{fileNameWithoutExtension}.md";
             MarkdownHelper.Write(mdFileName, mdTable);
-            OutputFileCallback?.Invoke(mdFileName);
+            LogFileSaved(mdFileName);
             Console.WriteLine(MarkdownHelper.ToTrimmedTable(mdTable));
         }
 

--- a/tests/scenariobenchmark/Program.cs
+++ b/tests/scenariobenchmark/Program.cs
@@ -1,0 +1,86 @@
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Api;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+
+namespace simpleharness
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            using (var harness = new XunitPerformanceHarness(args))
+            {
+                Console.Out.WriteLine($"[{DateTime.Now}] Harness start");
+                TestDir(harness);
+                Console.Out.WriteLine($"[{DateTime.Now}] Harness stop");
+            }
+        }
+
+        static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+        const int Iterations = 10;
+
+        private static void TestDir(XunitPerformanceHarness harness)
+        {
+            string commandName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dir" : "ls";
+
+            var testModel = new ScenarioTestModel(commandName);
+
+            testModel.Performance.Metrics.Add(new MetricModel
+            {
+                Name = "ExecutionTime",
+                DisplayName = "Execution Time",
+                Unit = "ms"
+            });
+
+            void PreIteration(ScenarioTest scenarioTest)
+            {
+
+            }
+
+            void PostIteration(ScenarioExecutionResult scenarioExecutionResult)
+            {
+                var elapsed = scenarioExecutionResult.ProcessExitInfo.ExitTime - scenarioExecutionResult.ProcessExitInfo.StartTime;
+
+                var iteration = new IterationModel
+                {
+                    Iteration = new Dictionary<string, double>()
+                };
+                iteration.Iteration.Add(testModel.Performance.Metrics[0].Name, elapsed.TotalMilliseconds);
+                testModel.Performance.IterationModels.Add(iteration);
+            }
+
+            void PostRun(ScenarioBenchmark scenario)
+            {
+
+            }
+
+            ProcessStartInfo processToMeasure;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                processToMeasure = new ProcessStartInfo("cmd", $"/c {commandName}");
+            }
+            else
+            {
+                processToMeasure = new ProcessStartInfo(commandName);
+            }            
+
+            var scenarioTestConfiguration = new ScenarioTestConfiguration(Timeout, processToMeasure);
+            scenarioTestConfiguration.Iterations = Iterations;
+            scenarioTestConfiguration.PreIterationDelegate = PreIteration;
+            scenarioTestConfiguration.PostIterationDelegate = PostIteration;
+            scenarioTestConfiguration.Scenario = new ScenarioBenchmark("ExecuteCommand");
+            scenarioTestConfiguration.Scenario.Tests.Add(testModel);
+            scenarioTestConfiguration.TestName = commandName;
+
+            harness.RunScenario(scenarioTestConfiguration, PostRun);
+        }
+    }
+}

--- a/tests/scenariobenchmark/scenariobenchmark.csproj
+++ b/tests/scenariobenchmark/scenariobenchmark.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Label="Configuration">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;;netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\xunit.performance.api\xunit.performance.api.csproj" />
+    <ProjectReference Include="..\..\src\xunit.performance.core\xunit.performance.core.csproj" />
+    <ProjectReference Include="..\..\src\xunit.performance.execution\xunit.performance.execution.csproj" />
+    <ProjectReference Include="..\..\src\xunit.performance.metrics\xunit.performance.metrics.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/xunit-performance.sln
+++ b/xunit-performance.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27031.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xunit.performance.core", "src\xunit.performance.core\xunit.performance.core.csproj", "{09595578-BF33-43DE-A6F7-400816841BA9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xunit.performance.api", "src\xunit.performance.api\xunit.performance.api.csproj", "{C614A260-70FE-48FB-A304-3B8CB78F304A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xunit.performance.execution", "src\xunit.performance.execution\xunit.performance.execution.csproj", "{83225E4E-AF27-4B24-B383-6D20F3AF2046}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xunit.performance.metrics", "src\xunit.performance.metrics\xunit.performance.metrics.csproj", "{71669F0E-51F2-4975-9247-30F0306F40D4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{14BC9B10-CF8D-4388-AD81-BFAD9BB16013}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "simpleharness", "tests\simpleharness\simpleharness.csproj", "{825C33D4-18FA-41D1-8BE6-C779B30297DB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "standalonesample", "tests\standalonesample\standalonesample.csproj", "{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{09595578-BF33-43DE-A6F7-400816841BA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09595578-BF33-43DE-A6F7-400816841BA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09595578-BF33-43DE-A6F7-400816841BA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09595578-BF33-43DE-A6F7-400816841BA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C614A260-70FE-48FB-A304-3B8CB78F304A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C614A260-70FE-48FB-A304-3B8CB78F304A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C614A260-70FE-48FB-A304-3B8CB78F304A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C614A260-70FE-48FB-A304-3B8CB78F304A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83225E4E-AF27-4B24-B383-6D20F3AF2046}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83225E4E-AF27-4B24-B383-6D20F3AF2046}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83225E4E-AF27-4B24-B383-6D20F3AF2046}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83225E4E-AF27-4B24-B383-6D20F3AF2046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71669F0E-51F2-4975-9247-30F0306F40D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71669F0E-51F2-4975-9247-30F0306F40D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71669F0E-51F2-4975-9247-30F0306F40D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71669F0E-51F2-4975-9247-30F0306F40D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{825C33D4-18FA-41D1-8BE6-C779B30297DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{825C33D4-18FA-41D1-8BE6-C779B30297DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{825C33D4-18FA-41D1-8BE6-C779B30297DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{825C33D4-18FA-41D1-8BE6-C779B30297DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{09595578-BF33-43DE-A6F7-400816841BA9} = {FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}
+		{C614A260-70FE-48FB-A304-3B8CB78F304A} = {FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}
+		{83225E4E-AF27-4B24-B383-6D20F3AF2046} = {FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}
+		{71669F0E-51F2-4975-9247-30F0306F40D4} = {FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}
+		{825C33D4-18FA-41D1-8BE6-C779B30297DB} = {14BC9B10-CF8D-4388-AD81-BFAD9BB16013}
+		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C} = {14BC9B10-CF8D-4388-AD81-BFAD9BB16013}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C5EB23E1-11A8-4BF0-AC18-0F7710E784DF}
+	EndGlobalSection
+EndGlobal

--- a/xunit-performance.sln
+++ b/xunit-performance.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "simpleharness", "tests\simp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "standalonesample", "tests\standalonesample\standalonesample.csproj", "{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "scenariobenchmark", "tests\scenariobenchmark\scenariobenchmark.csproj", "{791094C8-A32E-4931-9DCD-993D9490BD33}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{791094C8-A32E-4931-9DCD-993D9490BD33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{791094C8-A32E-4931-9DCD-993D9490BD33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{791094C8-A32E-4931-9DCD-993D9490BD33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{791094C8-A32E-4931-9DCD-993D9490BD33}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +66,7 @@ Global
 		{71669F0E-51F2-4975-9247-30F0306F40D4} = {FA082F5D-B78D-4D6C-B609-9F1C6E7E2A83}
 		{825C33D4-18FA-41D1-8BE6-C779B30297DB} = {14BC9B10-CF8D-4388-AD81-BFAD9BB16013}
 		{26D58C50-352F-43AA-BEEE-37C57AE2FF7C} = {14BC9B10-CF8D-4388-AD81-BFAD9BB16013}
+		{791094C8-A32E-4931-9DCD-993D9490BD33} = {14BC9B10-CF8D-4388-AD81-BFAD9BB16013}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C5EB23E1-11A8-4BF0-AC18-0F7710E784DF}


### PR DESCRIPTION
This makes some changes to scenario testing:

- Multiple tests can be run under a single `ScenarioBenchmark`
- Statistics output can be deferred in order to aggregate the results from multiple scenarios
- When creating tables for the results, it is possible to have a column for the scenario name

An example of code that uses the updated capabilities is here: https://github.com/dsplaisted/sdk/blob/17903b0e263aa0835d333f465972889b82670c21/test/Microsoft.NET.Perf.Tests/PerfTest.cs

It creates results like this:

Scenario Name             | Test Name          | Metric         | Unit | Iterations |    Average |  STDEV.S |        Min |        Max
:------------------------- |:------------------ |:-------------- |:----:|:----------:| ----------:| --------:| ----------:| ----------:
.NET Core 2 Console App   | Build              | Execution Time |  ms  |     9      |   2288.169 |   94.770 |   2155.042 |   2404.362
.NET Core 2 Console App   | Build (no changes) | Execution Time |  ms  |     9      |   1220.919 |   33.254 |   1165.615 |   1263.797
.NET Core 2 Console App   | Restore (No-op)    | Execution Time |  ms  |     9      |    797.782 |   16.235 |    765.929 |    817.410
.NET Standard 2.0 Library | Build              | Execution Time |  ms  |     9      |   1950.159 |  118.927 |   1824.096 |   2096.167
.NET Standard 2.0 Library | Build (no changes) | Execution Time |  ms  |     9      |    952.692 |   25.762 |    911.742 |    992.312
.NET Standard 2.0 Library | Restore (No-op)    | Execution Time |  ms  |     9      |    836.623 |   42.447 |    788.992 |    919.064
ASP.NET Core MVC app      | Build              | Execution Time |  ms  |     9      |   3702.768 |   64.516 |   3576.693 |   3827.518
ASP.NET Core MVC app      | Build (no changes) | Execution Time |  ms  |     9      |   2415.289 |   71.831 |   2330.799 |   2529.900
ASP.NET Core MVC app      | Restore (No-op)    | Execution Time |  ms  |     9      |   1123.686 |   24.170 |   1087.291 |   1154.485
LargeP2POldCsproj         | Build              | Execution Time |  ms  |     9      |  58004.077 | 2665.748 |  54163.415 |  62418.122
LargeP2POldCsproj         | Build (no changes) | Execution Time |  ms  |     9      |  10702.538 |  206.794 |  10459.133 |  10995.135
LargeP2POldCsproj         | Restore (No-op)    | Execution Time |  ms  |     9      |   5949.519 |  188.798 |   5757.808 |   6278.338
Roslyn                    | Build              | Execution Time |  ms  |     9      | 165812.729 | 9708.248 | 148006.225 | 177167.230
Roslyn                    | Build (no changes) | Execution Time |  ms  |     9      |  18321.198 | 1044.836 |  16394.047 |  19167.956
SmallP2PNewCsproj         | Build              | Execution Time |  ms  |     9      |   9009.427 |  921.782 |   7347.273 |   9809.446
SmallP2PNewCsproj         | Build (no changes) | Execution Time |  ms  |     9      |   5039.876 |  413.148 |   4309.214 |   5543.195
SmallP2PNewCsproj         | Restore (No-op)    | Execution Time |  ms  |     9      |   1550.481 |   46.974 |   1467.509 |   1610.993
SmallP2POldCsproj         | Build              | Execution Time |  ms  |     9      |   4549.422 |  122.519 |   4413.579 |   4796.330
SmallP2POldCsproj         | Build (no changes) | Execution Time |  ms  |     9      |   1401.622 |   30.569 |   1354.474 |   1459.674
SmallP2POldCsproj         | Restore (No-op)    | Execution Time |  ms  |     9      |    688.694 |   48.489 |    626.152 |    774.784
