### PR TITLE
The `ScenarioTestModel` is not serializing properly to Xml.

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0009
+  set VersionSuffix=beta-build0010
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/Model/AssemblyModel.cs
+++ b/src/xunit.performance.api/Model/AssemblyModel.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Xunit.Performance.Api
     public sealed class ScenarioTestModel
     {
         [XmlAttribute("Name")]
-        public string Name { get; }
+        public string Name { get; set; }
 
         [XmlAttribute("Namespace")]
         public string Namespace { get => _namespace; set => _namespace = value ?? ""; }


### PR DESCRIPTION
Serializing an object to Xml requires the properties to have public get/set, and the property `ScenarioTestModel.Name.set()` was private. This caused the serialized object not to have an Xml Name attribute which broke serialization to BenchView data.
