### PR TITLE
Small series of bug fixes

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0011
+  set VersionSuffix=beta-build0012
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/build.cmd
+++ b/build.cmd
@@ -71,8 +71,8 @@ setlocal
   )
 
   for %%v in (1.0 1.1 2.0) do (
-    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                || exit /b 1
-    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\simpleharness.dll" --perf:collect default+gcapi  || exit /b 1
+    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                                                                              || exit /b 1
+    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\simpleharness.dll" --perf:collect default+gcapi --perf:outputdir "%CD%\bin\%BuildConfiguration%\netcoreapp%%v" || exit /b 1
   )
 
   exit /b %errorlevel%
@@ -87,8 +87,8 @@ setlocal
   )
 
   for %%v in (1.0 1.1 2.0) do (
-    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                || exit /b 1
-    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\scenariobenchmark.dll" --perf:collect default    || exit /b 1
+    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                                                                            || exit /b 1
+    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\scenariobenchmark.dll" --perf:collect default --perf:outputdir "%CD%\bin\%BuildConfiguration%\netcoreapp%%v" || exit /b 1
   )
 
   exit /b %errorlevel%

--- a/src/xunit.performance.api/FunctionalExtensions.cs
+++ b/src/xunit.performance.api/FunctionalExtensions.cs
@@ -6,11 +6,11 @@ namespace Microsoft.Xunit.Performance.Api
     internal static class FunctionalExtensions
     {
         /// <summary>
-        /// Performs the specified action on each element of the IEnumerable&lt;T&gt;.
+        /// Performs the specified action on each element of the <see cref="System.Collections.Generic.IEnumerable{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of elements in the enumeration.</typeparam>
-        /// <param name="enumeration">An IEnumerable&lt;T&gt; to perform the specified action on each element.</param>
-        /// <param name="action">The Action&lt;T&gt; delegate to perform on each element of the IEnumerable&lt;T&gt;.</param>
+        /// <param name="enumeration">An <see cref="System.Collections.Generic.IEnumerable{T}"/> to perform the specified action on each element.</param>
+        /// <param name="action">The <see cref="System.Action{T}"/> delegate to perform on each element of the <see cref="System.Collections.Generic.IEnumerable{T}"/>.</param>
         public static void ForEach<T>(this IEnumerable<T> enumeration, Action<T> action)
         {
             foreach (T item in enumeration)
@@ -18,14 +18,11 @@ namespace Microsoft.Xunit.Performance.Api
         }
 
         /// <summary>
-        /// Creates a HashSet&lt;T&gt; from an IEnumerable&lt;T&gt;.
+        /// Creates a <see cref="System.Collections.Generic.HashSet{T}"/> from an <see cref="System.Collections.Generic.IEnumerable{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of the elements of source.</typeparam>
-        /// <param name="source">An IEnumerable&lt;T&gt; to create a HashSet&lt;T&gt; from.</param>
-        /// <returns>A HashSet&lt;T&gt; that contains a unique set of values of the source.</returns>
-        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source)
-        {
-            return new HashSet<T>(source);
-        }
+        /// <param name="source">An <see cref="System.Collections.Generic.IEnumerable{T}"/> to create a <see cref="System.Collections.Generic.HashSet{T}"/> from.</param>
+        /// <returns>A <see cref="System.Collections.Generic.HashSet{T}"/> that contains a unique set of values of the source.</returns>
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source) => new HashSet<T>(source);
     }
 }

--- a/src/xunit.performance.api/PerformanceMonitorCounter/BasePerformanceMonitorCounter.cs
+++ b/src/xunit.performance.api/PerformanceMonitorCounter/BasePerformanceMonitorCounter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xunit.Performance.Api
             get
             {
                 yield return new KernelProviderInfo() {
-                    Keywords = unchecked((ulong)(KernelTraceEventParser.Keywords.PMCProfile | KernelTraceEventParser.Keywords.Profile)),
+                    Keywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile),
                     StackKeywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile),
                 };
                 yield return new CpuCounterInfo() {

--- a/src/xunit.performance.api/Profilers/Etw/DotNetMethod.cs
+++ b/src/xunit.performance.api/Profilers/Etw/DotNetMethod.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
 {
     /// <summary>
@@ -9,43 +11,59 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
     internal sealed class DotNetMethod
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetMethod"/> class.
+        /// </summary>
+        /// <param name="id">Method id</param>
+        /// <param name="name">Method name</param>
+        /// <param name="namespace">Method namespace</param>
+        /// <param name="isDynamic">Flag indicating whether the method is dynamic.</param>
+        /// <param name="isGeneric">Flag indicating whether the method is generic.</param>
+        /// <param name="isJitted">Flag indicating whether the method is jitted.</param>
+        public DotNetMethod(long id, string name, string @namespace, bool isDynamic, bool isGeneric, bool isJitted)
+        {
+            Id = id;
+            Name = name;
+            Namespace = @namespace;
+            IsDynamic = isDynamic;
+            IsGeneric = isGeneric;
+            IsJitted = isJitted;
+
+            RuntimeInstances = new List<RuntimeInstance>();
+        }
+
+        /// <summary>
         /// Method's Id.
         /// </summary>
-        public long Id { get; set; }
+        public long Id { get; }
 
         /// <summary>
         /// Method's name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>
         /// Method's namespace.
         /// </summary>
-        public string Namespace { get; set; }
+        public string Namespace { get; }
 
         /// <summary>
         /// Gets a value indicating whether the associated method is dynamic.
         /// </summary>
-        internal bool IsDynamic { get; set; }
+        internal bool IsDynamic { get; }
 
         /// <summary>
         /// Gets a value indicating whether the associated method is generic.
         /// </summary>
-        internal bool IsGeneric { get; set; }
+        internal bool IsGeneric { get; }
 
         /// <summary>
         /// Gets a value indicating whether the associated method has been jitted.
         /// </summary>
-        internal bool IsJitted { get; set; }
+        internal bool IsJitted { get; }
 
         /// <summary>
-        /// Life span of this method (From the time it was loaded until the time it was unloaded).
+        /// A collection of runtime information (lifetime and loaded address) about this module.
         /// </summary>
-        internal LifeSpan LifeSpan { get; } = new LifeSpan();
-
-        /// <summary>
-        /// Represents the address space where this method was loaded.
-        /// </summary>
-        internal AddressSpace AddressSpace { get; set; }
+        internal IList<RuntimeInstance> RuntimeInstances { get; }
     }
 }

--- a/src/xunit.performance.api/Profilers/Etw/DotNetModule.cs
+++ b/src/xunit.performance.api/Profilers/Etw/DotNetModule.cs
@@ -15,9 +15,17 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         /// </summary>
         /// <param name="fullName"></param>
         /// <param name="checksum"></param>
+        /// <param name="monitoredCounters"></param>
         /// <param name="id"></param>
-        public DotNetModule(string fullName, int checksum, long id)
-           : base(fullName, checksum)
+        public DotNetModule(string fullName, int checksum, ISet<PerformanceMonitorCounter> monitoredCounters, long id)
+           : base(fullName, checksum, monitoredCounters)
+        {
+            Id = id;
+            Methods = new List<DotNetMethod>();
+        }
+
+        public DotNetModule(Module src, long id)
+            : base(src)
         {
             Id = id;
             Methods = new List<DotNetMethod>();

--- a/src/xunit.performance.api/Profilers/Etw/KernelProvider.cs
+++ b/src/xunit.performance.api/Profilers/Etw/KernelProvider.cs
@@ -12,9 +12,6 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
     {
         static KernelProvider()
         {
-            // Currently, all pmc set by the API have these flags set:
-            // - Flags = PMCProfile
-            // - StackCapture = PMCProfile
             Default = new KernelProvider {
                 Flags = KernelTraceEventParser.Keywords.ImageLoad
                     | KernelTraceEventParser.Keywords.Process

--- a/src/xunit.performance.api/Profilers/Etw/KernelProvider.cs
+++ b/src/xunit.performance.api/Profilers/Etw/KernelProvider.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         static KernelProvider()
         {
             // Currently, all pmc set by the API have these flags set:
-            // - Flags = Profile | PMCProfile
+            // - Flags = PMCProfile
             // - StackCapture = PMCProfile
             Default = new KernelProvider {
                 Flags = KernelTraceEventParser.Keywords.ImageLoad
                     | KernelTraceEventParser.Keywords.Process
+                    | KernelTraceEventParser.Keywords.Profile
                     | KernelTraceEventParser.Keywords.Thread,
-                StackCapture = KernelTraceEventParser.Keywords.ContextSwitch
-                    | KernelTraceEventParser.Keywords.SystemCall,
+                StackCapture = KernelTraceEventParser.Keywords.None,
             };
         }
 

--- a/src/xunit.performance.api/Profilers/Etw/Listener.cs
+++ b/src/xunit.performance.api/Profilers/Etw/Listener.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
             {
                 const string message = "The application is required to run as Administrator in order to capture kernel data.";
                 WriteErrorLine(message);
-                throw new InvalidOperationException(message);
+                throw new UnauthorizedAccessException(message);
             }
 
             TResult result;

--- a/src/xunit.performance.api/Profilers/Etw/Module.cs
+++ b/src/xunit.performance.api/Profilers/Etw/Module.cs
@@ -16,16 +16,33 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         /// </summary>
         /// <param name="fullName"></param>
         /// <param name="checksum"></param>
-        public Module(string fullName, int checksum)
+        /// <param name="monitoredCounters">A set of monitored <see cref="PerformanceMonitorCounter"/> counters.</param>
+        public Module(string fullName, int checksum, ISet<PerformanceMonitorCounter> monitoredCounters)
         {
             if (string.IsNullOrWhiteSpace(fullName))
                 throw new ArgumentNullException(nameof(fullName));
 
             FullName = fullName;
             Checksum = checksum;
-            LifeSpan = new LifeSpan();
 
             PerformanceMonitorCounterData = new Dictionary<PerformanceMonitorCounter, long>();
+            foreach (var pmc in monitoredCounters)
+                PerformanceMonitorCounterData.Add(pmc, 0);
+
+            RuntimeInstances = new List<RuntimeInstance>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Module"/> class (Copy constructor).
+        /// </summary>
+        /// <param name="src">Instance to be copied.</param>
+        public Module(Module src)
+        {
+            FullName = src.FullName;
+            Checksum = src.Checksum;
+
+            PerformanceMonitorCounterData = new Dictionary<PerformanceMonitorCounter, long>(src.PerformanceMonitorCounterData);
+            RuntimeInstances = new List<RuntimeInstance>(src.RuntimeInstances);
         }
 
         /// <summary>
@@ -44,13 +61,8 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         public IDictionary<PerformanceMonitorCounter, long> PerformanceMonitorCounterData { get; set; }
 
         /// <summary>
-        /// Represents the address space where this module was loaded.
+        /// A collection of runtime information (lifetime and loaded address) about this module.
         /// </summary>
-        internal AddressSpace AddressSpace { get; set; }
-
-        /// <summary>
-        /// Life span of this module (From the time it was loaded until the time it was unloaded).
-        /// </summary>
-        internal LifeSpan LifeSpan { get; }
+        internal IList<RuntimeInstance> RuntimeInstances { get; }
     }
 }

--- a/src/xunit.performance.api/Profilers/Etw/Process.cs
+++ b/src/xunit.performance.api/Profilers/Etw/Process.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         /// <param name="name">Process image file name</param>
         /// <param name="id">Process Id</param>
         /// <param name="parentId">Process' parent Id</param>
-        public Process(string name, int id, int parentId)
+        /// <param name="monitoredCounters">A set of monitored <see cref="PerformanceMonitorCounter"/> counters.</param>
+        public Process(string name, int id, int parentId, ISet<PerformanceMonitorCounter> monitoredCounters)
         {
             Name = name;
             Id = id;
@@ -24,6 +25,9 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
             LifeSpan = new LifeSpan();
 
             PerformanceMonitorCounterData = new Dictionary<PerformanceMonitorCounter, long>();
+            foreach (var pmc in monitoredCounters)
+                PerformanceMonitorCounterData.Add(pmc, 0);
+
             Modules = new List<Module>();
         }
 

--- a/src/xunit.performance.api/Profilers/Etw/RuntimeInstance.cs
+++ b/src/xunit.performance.api/Profilers/Etw/RuntimeInstance.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
+{
+    /// <summary>
+    /// Runtime information about the corresponding loaded code.
+    /// </summary>
+    internal sealed class RuntimeInstance
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuntimeInstance"/> class.
+        /// </summary>
+        /// <param name="addressSpace">The address space where this code was loaded.</param>
+        /// <param name="loadDateTime">The time when this code was loaded.</param>
+        public RuntimeInstance(AddressSpace addressSpace, DateTime loadDateTime)
+        {
+            AddressSpace = addressSpace;
+            LifeSpan = new LifeSpan { Start = loadDateTime, };
+        }
+
+        /// <summary>
+        /// Represents the address space where this code was loaded.
+        /// </summary>
+        internal AddressSpace AddressSpace { get; }
+
+        /// <summary>
+        /// Life span of this code in memory (From the time it was loaded until the time it was unloaded).
+        /// </summary>
+        internal LifeSpan LifeSpan { get; }
+    }
+}

--- a/src/xunit.performance.api/Profilers/Etw/SimpleTraceEventParser.cs
+++ b/src/xunit.performance.api/Profilers/Etw/SimpleTraceEventParser.cs
@@ -42,13 +42,11 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     || processes.Any(process => process.Id == obj.ProcessID || process.Id == obj.ParentID);
             }
 
-            Console.WriteLine($"[{DateTime.Now}] Parsing starts.");
             using (var source = new ETWTraceEventSource(scenarioExecutionResult.EventLogFileName))
             {
                 if (source.EventsLost > 0)
                     throw new Exception($"Events lost in trace '{scenarioExecutionResult.EventLogFileName}'");
 
-                const string UnknownModuleName = "Unknown";
                 const int DefaultModuleChecksum = 0;
 
                 ////////////////////////////////////////////////////////////////
@@ -317,6 +315,7 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                 }
 
                 // Map PMC to Unknown module.
+                const string UnknownModuleName = "Unknown";
                 pmcSamples
                     .GroupBy(pmc => pmc.ProcessId)
                     .Select(g1 => {
@@ -337,8 +336,6 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                         });
                         process.Modules.Add(newModule);
                     });
-
-                Console.WriteLine($"[{DateTime.Now}] Parsing ends.");
 
                 return processes;
             }

--- a/src/xunit.performance.api/Profilers/Etw/SimpleTraceEventParser.cs
+++ b/src/xunit.performance.api/Profilers/Etw/SimpleTraceEventParser.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
 {
@@ -28,6 +29,9 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         /// </remarks>
         public IReadOnlyCollection<Process> GetProfileData(ScenarioExecutionResult scenarioExecutionResult)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                throw new PlatformNotSupportedException();
+
             var processes = new List<Process>();
             Module defaultNtoskrnlModule = null;
             var pmcSamplingIntervals = new Dictionary<int, long>();
@@ -38,6 +42,7 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     || processes.Any(process => process.Id == obj.ProcessID || process.Id == obj.ParentID);
             }
 
+            Console.WriteLine($"[{DateTime.Now}] Parsing starts.");
             using (var source = new ETWTraceEventSource(scenarioExecutionResult.EventLogFileName))
             {
                 if (source.EventsLost > 0)
@@ -52,7 +57,7 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                 parser.ProcessStart += (ProcessTraceData obj) => {
                     if (IsOurProcess(obj))
                     {
-                        var process = new Process(obj.ImageFileName, obj.ProcessID, obj.ParentID);
+                        var process = new Process(obj.ImageFileName, obj.ProcessID, obj.ParentID, scenarioExecutionResult.PerformanceMonitorCounters);
                         process.LifeSpan.Start = obj.TimeStamp;
                         processes.Add(process);
                     }
@@ -69,25 +74,34 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     if (process == null)
                         return;
 
-                    var module = new Module(obj.FileName, obj.ImageChecksum) {
-                        AddressSpace = new AddressSpace(obj.ImageBase, (uint)obj.ImageSize)
-                    };
-                    module.LifeSpan.Start = obj.TimeStamp;
-
-                    process.Modules.Add(module);
+                    var module = process.Modules
+                        .SingleOrDefault(m => m.Checksum == obj.ImageChecksum && m.FullName == obj.FileName);
+                    if (module == null)
+                    {
+                        module = new Module(obj.FileName, obj.ImageChecksum, scenarioExecutionResult.PerformanceMonitorCounters);
+                        process.Modules.Add(module);
+                    }
+                    module.RuntimeInstances.Add(
+                        new RuntimeInstance(new AddressSpace(obj.ImageBase, (uint)obj.ImageSize), obj.TimeStamp));
                 };
                 parser.ImageUnload += (ImageLoadTraceData obj) => {
                     var process = processes.SingleOrDefault(p => p.Id == obj.ProcessID);
                     if (process == null)
                         return;
 
-                    // Check if the unloaded module is on the list.
-                    // The module must be loaded, in the same address space, and same file name.
                     var module = process.Modules
-                        .SingleOrDefault(m => m.LifeSpan.IsInInterval(obj.TimeStamp) == 0 && obj.Equivalent(m));
+                        .SingleOrDefault(m => m.Checksum == obj.ImageChecksum && m.FullName == obj.FileName);
                     if (module == null)
                         return;
-                    module.LifeSpan.End = obj.TimeStamp;
+
+                    var info = module.RuntimeInstances.SingleOrDefault(i => {
+                        return i.AddressSpace.Start == obj.ImageBase
+                            && i.AddressSpace.Size == obj.ImageSize
+                            && i.LifeSpan.End > obj.TimeStamp;
+                    });
+                    if (info == null)
+                        return; // Managed methods already unloaded.
+                    info.LifeSpan.End = obj.TimeStamp;
                 };
 
                 ////////////////////////////////////////////////////////////////
@@ -97,11 +111,9 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     {
                         if (defaultNtoskrnlModule == null)
                         {
-                            defaultNtoskrnlModule = new Module(obj.FileName, obj.ImageChecksum) {
-                                AddressSpace = new AddressSpace(obj.ImageBase, (uint)obj.ImageSize)
-                            };
-                            defaultNtoskrnlModule.LifeSpan.Start = obj.TimeStamp;
-                            defaultNtoskrnlModule.LifeSpan.End = DateTime.MaxValue;
+                            defaultNtoskrnlModule = new Module(obj.FileName, obj.ImageChecksum, scenarioExecutionResult.PerformanceMonitorCounters);
+                            defaultNtoskrnlModule.RuntimeInstances.Add(
+                                new RuntimeInstance(new AddressSpace(obj.ImageBase, (uint)obj.ImageSize), obj.TimeStamp));
                         }
                     }
                 };
@@ -120,30 +132,25 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     }
                 };
                 parser.PerfInfoPMCSample += (PMCCounterProfTraceData obj) => {
-                    var process = processes.SingleOrDefault(p => p.Id == obj.ProcessID);
-                    if (process == null)
-                        return;
-
                     var performanceMonitorCounter = scenarioExecutionResult.PerformanceMonitorCounters
                         .SingleOrDefault(pmc => pmc.Id == obj.ProfileSource);
                     if (performanceMonitorCounter == null)
                         return;
 
-                    // If this is our process and it is a Pmc we care to measure.
-                    if (!process.PerformanceMonitorCounterData.ContainsKey(performanceMonitorCounter))
-                        process.PerformanceMonitorCounterData.Add(performanceMonitorCounter, 0);
+                    var process = processes.SingleOrDefault(p => p.Id == obj.ProcessID);
+                    if (process == null)
+                        return;
+
                     process.PerformanceMonitorCounterData[performanceMonitorCounter] += pmcSamplingIntervals[obj.ProfileSource];
 
                     // Is the IP in the kernel (Under this process)?
                     if (defaultNtoskrnlModule != null && obj.IsInTimeAndAddressIntervals(defaultNtoskrnlModule))
                     {
                         var krnlModule = process.Modules
-                            .SingleOrDefault(m => m.Checksum == defaultNtoskrnlModule.Checksum
-                                && m.AddressSpace == defaultNtoskrnlModule.AddressSpace
-                                && m.FullName == defaultNtoskrnlModule.FullName);
+                            .SingleOrDefault(m => m.Checksum == defaultNtoskrnlModule.Checksum && m.FullName == defaultNtoskrnlModule.FullName);
                         if (krnlModule == null)
                         {
-                            krnlModule = defaultNtoskrnlModule.Copy();
+                            krnlModule = new Module(defaultNtoskrnlModule);
                             process.Modules.Add(krnlModule);
                         }
                     }
@@ -168,8 +175,6 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     }
 
                     modules.ForEach(module => {
-                        if (!module.PerformanceMonitorCounterData.ContainsKey(performanceMonitorCounter))
-                            module.PerformanceMonitorCounterData.Add(performanceMonitorCounter, 0);
                         module.PerformanceMonitorCounterData[performanceMonitorCounter] += pmcSamplingIntervals[obj.ProfileSource];
                     });
                 };
@@ -183,23 +188,19 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
 
                     var modulePath = string.IsNullOrEmpty(obj.ModuleNativePath) ? obj.ModuleILPath : obj.ModuleNativePath;
                     var module = process.Modules
-                        .SingleOrDefault(m => m.FullName == modulePath && m.LifeSpan.IsInInterval(obj.TimeStamp) == 0);
+                        .SingleOrDefault(m => m.FullName == modulePath && m.RuntimeInstances.Any(i => i.LifeSpan.IsInInterval(obj.TimeStamp) == 0));
                     if (module == null)
                     {
                         // Not previously loaded (For example, 'Anonymously Hosted DynamicMethods Assembly')
-                        module = new DotNetModule(modulePath, DefaultModuleChecksum, obj.ModuleID);
+                        module = new DotNetModule(modulePath, DefaultModuleChecksum, scenarioExecutionResult.PerformanceMonitorCounters, obj.ModuleID);
                         process.Modules.Add(module);
                     }
                     else
                     {
                         // Update/Swap the module. It is a .NET module.
-                        var dotnetModule = new DotNetModule(module.FullName, module.Checksum, obj.ModuleID) {
-                            AddressSpace = module.AddressSpace,
-                        };
-                        dotnetModule.LifeSpan.Start = obj.TimeStamp;
-
-                        process.Modules.Remove(module);
-                        process.Modules.Add(dotnetModule);
+                        var dotnetModule = new DotNetModule(module, obj.ModuleID);
+                        process.Modules.Remove(module);     // Remove existing
+                        process.Modules.Add(dotnetModule);  // Add it back as managed
                     }
                 };
                 parser.Source.Clr.LoaderModuleUnload += (ModuleLoadUnloadTraceData obj) => {
@@ -210,10 +211,15 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
 
                     var module = process.Modules
                         .OfType<DotNetModule>()
-                        .SingleOrDefault(m => m.Id == obj.ModuleID);
+                        .SingleOrDefault(m => m.Id == obj.ModuleID && m.RuntimeInstances.Count > 0);
                     if (module == null)
                         return;
-                    module.LifeSpan.End = obj.TimeStamp;
+
+                    var info = module.RuntimeInstances
+                        .SingleOrDefault(i => i.LifeSpan.IsInInterval(obj.TimeStamp) == 0);
+                    if (info == null)
+                        throw new InvalidOperationException($"Unloading non-loaded .NET module: {(string.IsNullOrEmpty(obj.ModuleNativePath) ? obj.ModuleILPath : obj.ModuleNativePath)}");
+                    info.LifeSpan.End = obj.TimeStamp;
                 };
 
                 ////////////////////////////////////////////////////////////////
@@ -229,7 +235,7 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                         .SingleOrDefault(m => m.Id == obj.ModuleID);
                     if (module == null)
                     {
-                        var clrHelpersModule = new DotNetModule("$CLRHelpers$", DefaultModuleChecksum, 0);
+                        var clrHelpersModule = new DotNetModule("$CLRHelpers$", DefaultModuleChecksum, scenarioExecutionResult.PerformanceMonitorCounters, 0);
                         process.Modules.Add(clrHelpersModule);
                         module = clrHelpersModule;
                     }
@@ -238,19 +244,19 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                         .SingleOrDefault(m => m.Id == obj.MethodID);
                     if (method == null)
                     {
-                        method = new DotNetMethod {
-                            Id = obj.MethodID,
-                            AddressSpace = new AddressSpace(obj.MethodStartAddress, (uint)obj.MethodSize),
-                            IsDynamic = obj.IsDynamic,
-                            IsGeneric = obj.IsGeneric,
-                            IsJitted = obj.IsJitted,
-                            Name = obj.MethodName,
-                            Namespace = obj.MethodNamespace,
-                        };
-                        method.LifeSpan.Start = obj.TimeStamp;
+                        method = new DotNetMethod(
+                            obj.MethodID,
+                            obj.MethodName,
+                            obj.MethodNamespace,
+                            obj.IsDynamic,
+                            obj.IsGeneric,
+                            obj.IsJitted
+                        );
 
                         module.Methods.Add(method);
                     }
+                    method.RuntimeInstances.Add(
+                        new RuntimeInstance(new AddressSpace(obj.MethodStartAddress, (uint)obj.MethodSize), obj.TimeStamp));
                 };
                 parser.Source.Clr.MethodUnloadVerbose += (MethodLoadUnloadVerboseTraceData obj) => {
                     var process = processes.SingleOrDefault(p => p.Id == obj.ProcessID);
@@ -268,10 +274,19 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     if (method == null)
                         return;
 
-                    method.LifeSpan.End = obj.TimeStamp;
+                    var info = method.RuntimeInstances.SingleOrDefault(i => {
+                        return i.AddressSpace.Start == obj.MethodStartAddress
+                            && i.AddressSpace.Size == obj.MethodSize
+                            && i.LifeSpan.End > obj.TimeStamp;
+                    });
+                    if (info == null)
+                        throw new InvalidOperationException($"Unloading non-loaded .NET method: {obj.MethodName}");
+                    info.LifeSpan.End = obj.TimeStamp;
                 };
 
                 source.Process();
+
+                // TODO: We could order modules/methods by timestamp, then by address?
 
                 // Map PMC to managed modules.
                 for (int i = pmcSamples.Count - 1; i >= 0; i--)
@@ -289,14 +304,12 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                         .ForEach(module => {
                             var methodsCount = module.Methods
                                 .Where(m => {
-                                    return m.LifeSpan.IsInInterval(pmc.TimeStamp) == 0
-                                        && m.AddressSpace.IsInInterval(pmc.InstructionPointer) == 0;
+                                    return m.RuntimeInstances.Any(info => info.LifeSpan.IsInInterval(pmc.TimeStamp) == 0
+                                        && info.AddressSpace.IsInInterval(pmc.InstructionPointer) == 0);
                                 })
                                 .Count();
                             if (methodsCount != 0)
                             {
-                                if (!module.PerformanceMonitorCounterData.ContainsKey(performanceMonitorCounter))
-                                    module.PerformanceMonitorCounterData.Add(performanceMonitorCounter, 0);
                                 module.PerformanceMonitorCounterData[performanceMonitorCounter] += pmc.SamplingInterval;
                                 pmcSamples.RemoveAt(i);
                             }
@@ -318,10 +331,14 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                     })
                     .ForEach(pmcRollover => {
                         var process = processes.Single(p => p.Id == pmcRollover.ProcessId);
-                        process.Modules.Add(new Module(UnknownModuleName, DefaultModuleChecksum) {
-                            PerformanceMonitorCounterData = pmcRollover.PerformanceMonitorCounters,
+                        var newModule = new Module(UnknownModuleName, DefaultModuleChecksum, scenarioExecutionResult.PerformanceMonitorCounters);
+                        pmcRollover.PerformanceMonitorCounters.ForEach(pair => {
+                            newModule.PerformanceMonitorCounterData[pair.Key] = pair.Value;
                         });
+                        process.Modules.Add(newModule);
                     });
+
+                Console.WriteLine($"[{DateTime.Now}] Parsing ends.");
 
                 return processes;
             }
@@ -330,44 +347,12 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
 
     static class Extensions
     {
-        internal static bool Equivalent(this ImageLoadTraceData @this, Module module)
-        {
-            if (module.AddressSpace != null)
-            {
-                return module.AddressSpace.Start == @this.ImageBase
-                    && module.AddressSpace.Size == @this.ImageSize
-                    && module.Checksum == @this.ImageChecksum
-                    && module.FullName == @this.FileName;
-            }
-            else
-            {
-                // For example, 'Anonymously Hosted DynamicMethods Assembly'
-                return module.Checksum == @this.ImageChecksum && module.FullName == @this.FileName;
-            }
-        }
-
         internal static bool IsInTimeAndAddressIntervals(this PMCCounterProfTraceData @this, Module module)
         {
-            return module.LifeSpan.IsInInterval(@this.TimeStamp) == 0
-                && module.AddressSpace != null // For example, 'Anonymously Hosted DynamicMethods Assembly'
-                && module.AddressSpace.IsInInterval(@this.InstructionPointer) == 0;
-        }
-
-        /// <summary>
-        /// Creates a new object that is a deep copy of the current instance.
-        /// </summary>
-        /// <returns>A new object that is a deep copy of this instance.</returns>
-        internal static Module Copy(this Module @this)
-        {
-            var newModule = new Module(@this.FullName, @this.Checksum) {
-                AddressSpace = @this.AddressSpace,
-                PerformanceMonitorCounterData = new Dictionary<PerformanceMonitorCounter, long>(@this.PerformanceMonitorCounterData),
-            };
-
-            newModule.LifeSpan.Start = @this.LifeSpan.Start;
-            newModule.LifeSpan.End = @this.LifeSpan.End;
-
-            return newModule;
+            return module.RuntimeInstances
+                .Any(i => i.LifeSpan.IsInInterval(@this.TimeStamp) == 0
+                    && i.AddressSpace != null // For example, 'Anonymously Hosted DynamicMethods Assembly'
+                    && i.AddressSpace.IsInInterval(@this.InstructionPointer) == 0);
         }
     }
 }

--- a/src/xunit.performance.api/Profilers/Etw/UserProvider.cs
+++ b/src/xunit.performance.api/Profilers/Etw/UserProvider.cs
@@ -24,7 +24,11 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
                 },
                 new UserProvider {
                     Guid = ClrTraceEventParser.ProviderGuid,
-                    Keywords = (ulong)(ClrTraceEventParser.Keywords.Exception | ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.JittedMethodILToNativeMap | ClrTraceEventParser.Keywords.Loader),
+                    Keywords = (ulong)(ClrTraceEventParser.Keywords.Exception
+                        | ClrTraceEventParser.Keywords.GC
+                        | ClrTraceEventParser.Keywords.Jit
+                        | ClrTraceEventParser.Keywords.Loader
+                        | ClrTraceEventParser.Keywords.NGen),
                     Level = TraceEventLevel.Verbose,
                 },
             };
@@ -55,6 +59,6 @@ namespace Microsoft.Xunit.Performance.Api.Profilers.Etw
         /// <summary>
         /// Default ETW user providers enabled by the xUnit-Performance Api.
         /// </summary>
-        public static IReadOnlyCollection<UserProvider> Defaults { get; set; }
+        public static IReadOnlyCollection<UserProvider> Defaults { get; }
     }
 }

--- a/src/xunit.performance.api/SafeTerminateHandler.cs
+++ b/src/xunit.performance.api/SafeTerminateHandler.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Xunit.Performance.Api
         where T : class, IDisposable
     {
         /// <summary>
-        /// Initializes a new instance of the SafeTerminateHandler&lt;T&gt; class that
+        /// Initializes a new instance of the <see cref="SafeTerminateHandler{T}"/> class that
         /// wraps a disposable object that will be created by calling the
         /// specified callback Func.
         /// </summary>
-        /// <param name="createCallback">A method that has no parameters and returns a new disposable object of the type specified by the T parameter.</param>
+        /// <param name="createCallback">A method that has no parameters and returns a new disposable object of the type specified by the <typeparamref name="T"/> parameter.</param>
         public SafeTerminateHandler(Func<T> createCallback)
         {
             _disposedValue = true;
@@ -53,6 +53,9 @@ namespace Microsoft.Xunit.Performance.Api
             }
         }
 
+        /// <summary>
+        /// Gets the base disposable object wrap by this handler.
+        /// </summary>
         public T BaseDisposableObject { get; }
 
         private readonly Kernel32.PHANDLER_ROUTINE _HandlerRoutine;

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Xunit.Performance.Api
                 }
                 else
                 {
-                    testName = configuration.Scenario.Name + " - " + configuration.TestName;
+                    testName = $"{configuration.Scenario.Name}-{configuration.TestName}";
                 }
             }
 

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -158,7 +158,9 @@ namespace Microsoft.Xunit.Performance.Api
 
                     configuration.PreIterationDelegate?.Invoke(scenarioTest);
 
-                    WriteInfoLine($"Iteration ({i}): \"{scenarioTest.Process.StartInfo.FileName}\" {scenarioTest.Process.StartInfo.Arguments}");
+                    WriteInfoLine($"Iteration ({i})");
+                    WriteInfoLine($"  Working Directory: \"{scenarioTest.Process.StartInfo.WorkingDirectory}\"");
+                    WriteInfoLine($"  Command: \"{scenarioTest.Process.StartInfo.FileName}\" {scenarioTest.Process.StartInfo.Arguments}");
 
                     if (IsWindowsPlatform && _requireEtw)
                     {

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -10,15 +10,22 @@ using static Microsoft.Xunit.Performance.Api.PerformanceLogger;
 
 namespace Microsoft.Xunit.Performance.Api
 {
+    /// <summary>
+    /// This is the main entry point of the xUnit Performance Api.
+    /// It provides the functionality to run xUnit microbenchmarks and full benchmark scenarios.
+    /// </summary>
     public sealed class XunitPerformanceHarness : IDisposable
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XunitPerformanceHarness"/> class.
+        /// </summary>
+        /// <param name="args">String array that contains any command-line arguments passed in.</param>
         public XunitPerformanceHarness(string[] args)
         {
             _args = new string[args.Length];
             args.CopyTo(_args, 0);
 
             _disposed = false;
-            _outputFiles = new List<string>();
 
             var options = XunitPerformanceHarnessOptions.Parse(_args);
 
@@ -32,12 +39,26 @@ namespace Microsoft.Xunit.Performance.Api
             Configuration.FileLogPath = $"{Configuration.RunId}.csv"; // TODO: Conditionally set this based on whether we want a csv file written.
         }
 
+        /// <summary>
+        /// Gets the path for the output directory.
+        /// </summary>
         public string OutputDirectory { get; }
 
+        /// <summary>
+        /// Gets a collection of the type names of the test classes to run.
+        /// </summary>
+        /// <remarks>Returns an empty collection if the type names were not specified.</remarks>
         public IEnumerable<string> TypeNames => _typeNames.AsReadOnly();
 
+        /// <summary>
+        /// 
+        /// </summary>
         public BenchmarkConfiguration Configuration => BenchmarkConfiguration.Instance;
 
+        /// <summary>
+        /// Run the xUnit tests tagged with the [<see cref="BenchmarkAttribute"/>] attribute.
+        /// </summary>
+        /// <param name="assemblyFileName">Path to the assembly that contains the xUnit performance tests.</param>
         public void RunBenchmarks(string assemblyFileName)
         {
             if (string.IsNullOrEmpty(assemblyFileName))
@@ -45,27 +66,26 @@ namespace Microsoft.Xunit.Performance.Api
             if (!File.Exists(assemblyFileName))
                 throw new FileNotFoundException(assemblyFileName);
 
-            Action<string> xUnitAction = (assemblyPath) => { XunitRunner.Run(assemblyPath, _typeNames); };
+            void xUnitAction(string assemblyPath)
+            {
+                XunitRunner.Run(assemblyPath, _typeNames);
+            }
+
             var xUnitPerformanceSessionData = new XUnitPerformanceSessionData {
                 AssemblyFileName = assemblyFileName,
-                CollectOutputFilesCallback = (fileName) => {
-                    // FIXME: This will need safe guards when the client calls RunBenchmarks in different threads.
-                    _outputFiles.Add(fileName);
-                    WriteInfoLine($"File saved to: \"{fileName}\"");
-                },
+                CollectOutputFilesCallback = LogFileSaved,
                 OutputDirectory = OutputDirectory,
                 RunId = Configuration.RunId
             };
 
-            var metrics = _metricCollectionFactory.GetMetrics();
             var xUnitPerformanceMetricData = XunitBenchmark.GetMetadata(
                 assemblyFileName,
-                metrics,
+                _metricCollectionFactory.GetMetrics(),
                 _collectDefaultXUnitMetrics);
 
             if (IsWindowsPlatform && _requireEtw)
             {
-                Action winRunner = () => { xUnitAction(assemblyFileName); };
+                void winRunner() { xUnitAction(assemblyFileName); }
                 ETWProfiler.Record(
                     xUnitPerformanceSessionData,
                     xUnitPerformanceMetricData,
@@ -73,12 +93,18 @@ namespace Microsoft.Xunit.Performance.Api
             }
             else
             {
-                xUnitAction.Invoke(assemblyFileName);
+                xUnitAction(assemblyFileName);
                 ProcessResults(xUnitPerformanceSessionData, xUnitPerformanceMetricData);
             }
         }
 
-        static void LogFileSaved(string fileName) {
+        /// <summary>
+        /// Helper function.
+        /// Writes the the file name, followed by the current line terminator, to the standard output stream.
+        /// </summary>
+        /// <param name="fileName">Created file name.</param>
+        private static void LogFileSaved(string fileName)
+        {
             WriteInfoLine($"File saved to: \"{fileName}\"");
         }
 
@@ -132,7 +158,7 @@ namespace Microsoft.Xunit.Performance.Api
 
                     configuration.PreIterationDelegate?.Invoke(scenarioTest);
 
-                    WriteInfoLine($"$ {Path.GetFileName(scenarioTest.Process.StartInfo.FileName)} {scenarioTest.Process.StartInfo.Arguments}");
+                    WriteInfoLine($"Iteration ({i}): \"{scenarioTest.Process.StartInfo.FileName}\" {scenarioTest.Process.StartInfo.Arguments}");
 
                     if (IsWindowsPlatform && _requireEtw)
                     {
@@ -368,6 +394,9 @@ namespace Microsoft.Xunit.Performance.Api
 
         #region IDisposable implementation
 
+        /// <summary>
+        /// Performs tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -401,7 +430,6 @@ namespace Microsoft.Xunit.Performance.Api
         #endregion IDisposable implementation
 
         private readonly string[] _args;
-        private readonly List<string> _outputFiles;
         private readonly List<string> _typeNames;
         private readonly IPerformanceMetricFactory _metricCollectionFactory;
         private readonly bool _collectDefaultXUnitMetrics;

--- a/src/xunit.performance.execution/BenchmarkTestInvoker.cs
+++ b/src/xunit.performance.execution/BenchmarkTestInvoker.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Xunit.Performance
             {
                 GC.Collect(2, GCCollectionMode.Forced);
                 GC.WaitForPendingFinalizers();
+                GC.Collect(2, GCCollectionMode.Forced);
 
                 for (_currentIteration = 0; !DoneIterating; _currentIteration++)
                 {

--- a/src/xunit.performance.metrics/InstructionsRetiredMetric.cs
+++ b/src/xunit.performance.metrics/InstructionsRetiredMetric.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xunit.Performance
                 get
                 {
                     yield return new KernelProviderInfo() {
-                        Keywords = unchecked((ulong)(KernelTraceEventParser.Keywords.PMCProfile | KernelTraceEventParser.Keywords.Profile)),
+                        Keywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile),
                         StackKeywords = unchecked((ulong)KernelTraceEventParser.Keywords.PMCProfile),
                     };
                     yield return new CpuCounterInfo() {

--- a/tests/scenariobenchmark/Program.cs
+++ b/tests/scenariobenchmark/Program.cs
@@ -1,13 +1,8 @@
-using Microsoft.Xunit.Performance;
 using Microsoft.Xunit.Performance.Api;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Xunit;
 
 
 namespace simpleharness
@@ -65,18 +60,22 @@ namespace simpleharness
             ProcessStartInfo processToMeasure;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                processToMeasure = new ProcessStartInfo("cmd", $"/c {commandName}");
+                processToMeasure = new ProcessStartInfo("cmd.exe", $"/c {commandName}");
             }
             else
             {
                 processToMeasure = new ProcessStartInfo(commandName);
-            }            
+            }
 
-            var scenarioTestConfiguration = new ScenarioTestConfiguration(Timeout, processToMeasure);
-            scenarioTestConfiguration.Iterations = Iterations;
-            scenarioTestConfiguration.PreIterationDelegate = PreIteration;
-            scenarioTestConfiguration.PostIterationDelegate = PostIteration;
-            scenarioTestConfiguration.Scenario = new ScenarioBenchmark("ExecuteCommand");
+            processToMeasure.RedirectStandardError = true;
+            processToMeasure.RedirectStandardOutput = true;
+
+            var scenarioTestConfiguration = new ScenarioTestConfiguration(Timeout, processToMeasure) {
+                Iterations = Iterations,
+                PreIterationDelegate = PreIteration,
+                PostIterationDelegate = PostIteration,
+                Scenario = new ScenarioBenchmark("ExecuteCommand")
+            };
             scenarioTestConfiguration.Scenario.Tests.Add(testModel);
             scenarioTestConfiguration.TestName = commandName;
 

--- a/tests/simpleharness/simpleharness.csproj
+++ b/tests/simpleharness/simpleharness.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Remove an extra ; from the `<TargetFrameworks>` on the simpleharness.csproj file.
- xUnit micro-benchmarks harness: Call `GC.Collect` once more right after `GC.WaitForPendingFinalizers`
- Added more docstrings to public apis
- Updated the default Etw kernel/user providers, and remove duplication
- Minor changes in the xUnit Api tests verbosity
- Handle parsing `$CLRHELPERS$` methods generated by the Jit on x86
- Handle reloading unloaded modules

What is missing here?
- Implementation is complete and correct, but performance is not the best, it can be improved.