### PR TITLE
System.Diagnostics.Process has a different behavior on non-Windows platforms

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0012
+  set VersionSuffix=beta-build0013
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/ProcessExitInfo.cs
+++ b/src/xunit.performance.api/ProcessExitInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -26,17 +25,8 @@ namespace Microsoft.Xunit.Performance.Api
 
             ProcessId = process.Id;
             ExitCode = process.ExitCode;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                StartTime = process.StartTime;
-                ExitTime = process.ExitTime;
-            }
-            else
-            {
-                StartTime = startTime;
-                ExitTime = exitTime;
-            }
+            StartTime = startTime;
+            ExitTime = exitTime;
         }
 
         /// <summary>

--- a/src/xunit.performance.api/ProcessExitInfo.cs
+++ b/src/xunit.performance.api/ProcessExitInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -11,18 +12,31 @@ namespace Microsoft.Xunit.Performance.Api
         /// <summary>
         /// Initializes a new instance of a ProcessExitInfo class with the run process.
         /// </summary>
-        /// <param name="process"></param>
-        public ProcessExitInfo(Process process)
+        /// <param name="process">The terminated process.</param>
+        /// <param name="startTime">The time that the associated process was started.</param>
+        /// <param name="exitTime">The time that the associated process exited.</param>
+        internal ProcessExitInfo(Process process, DateTime startTime, DateTime exitTime)
         {
             if (process == null)
                 throw new ArgumentNullException(nameof(process));
             if (!process.HasExited)
                 throw new InvalidOperationException($"{process.ProcessName} has not exited.");
+            if (exitTime < startTime)
+                throw new InvalidOperationException($"Process.ExitTime: {exitTime}, is less than the Process.StartTime: {startTime}.");
 
             ProcessId = process.Id;
             ExitCode = process.ExitCode;
-            StartTime = process.StartTime;
-            ExitTime = process.ExitTime;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                StartTime = process.StartTime;
+                ExitTime = process.ExitTime;
+            }
+            else
+            {
+                StartTime = startTime;
+                ExitTime = exitTime;
+            }
         }
 
         /// <summary>

--- a/src/xunit.performance.api/ScenarioExecutionResult.cs
+++ b/src/xunit.performance.api/ScenarioExecutionResult.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Xunit.Performance.Api.Profilers.Etw;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Microsoft.Xunit.Performance.Api
 {
@@ -16,10 +16,12 @@ namespace Microsoft.Xunit.Performance.Api
         /// Initializes a new instance of the ScenarioExecutionResult class.
         /// </summary>
         /// <param name="process">Scenario benchmark process that was run.</param>
+        /// <param name="startTime">The time that the associated process was started.</param>
+        /// <param name="exitTime">The time that the associated process exited.</param>
         /// <param name="configuration">Configuration for the scenario that was run.</param>
-        public ScenarioExecutionResult(System.Diagnostics.Process process, ScenarioTestConfiguration configuration)
+        internal ScenarioExecutionResult(System.Diagnostics.Process process, DateTime startTime, DateTime exitTime, ScenarioTestConfiguration configuration)
         {
-            ProcessExitInfo = new ProcessExitInfo(process);
+            ProcessExitInfo = new ProcessExitInfo(process, startTime, exitTime);
             Configuration = configuration;
         }
 


### PR DESCRIPTION
- The `Process.StartTime` throw `System.ComponentModel.Win32Exception` on Linux because the data is not available once the process exits.
