### PR TITLE
Creating new Desktop binaries to unblock Desktop support.

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0013
+  set VersionSuffix=beta-build0014
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/build.cmd
+++ b/build.cmd
@@ -26,6 +26,12 @@ setlocal enabledelayedexpansion
   set procedures=%procedures% build_xunit_performance_execution
   set procedures=%procedures% build_xunit_performance_metrics
   set procedures=%procedures% build_xunit_performance_api
+
+  net.exe session 1>nul 2>&1 || (
+    call :print_error_message Cannot run tests because this is not an administrator window.
+    exit /b 1
+  )
+
   set procedures=%procedures% build_tests_simpleharness
   set procedures=%procedures% build_tests_scenariobenchmark
 
@@ -65,14 +71,16 @@ setlocal
 setlocal
   cd /d %~dp0tests\simpleharness
   call :dotnet_build || exit /b 1
-  net.exe session 1>nul 2>&1 || (
-    call :print_error_message Cannot run simpleharness test because this is not an administrator window
-    exit /b 1
-  )
 
-  for %%v in (1.0 1.1 2.0) do (
-    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                                                                              || exit /b 1
-    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\simpleharness.dll" --perf:collect default+gcapi --perf:outputdir "%CD%\bin\%BuildConfiguration%\netcoreapp%%v" || exit /b 1
+  for %%v in (netcoreapp1.0 netcoreapp1.1 netcoreapp2.0 net461) do (
+    dotnet.exe publish -c %BuildConfiguration% --framework "%%v"                            || exit /b 1
+    pushd ".\bin\%BuildConfiguration%\%%v\publish"
+    if "%%v" == "net461" (
+      ".\simpleharness.exe"            --perf:collect default+gcapi --perf:outputdir "!cd!" || exit /b 1
+    ) else (
+      dotnet.exe ".\simpleharness.dll" --perf:collect default+gcapi --perf:outputdir "!cd!" || exit /b 1
+    )
+    popd
   )
 
   exit /b %errorlevel%
@@ -81,14 +89,16 @@ setlocal
 setlocal
   cd /d %~dp0tests\scenariobenchmark
   call :dotnet_build || exit /b 1
-  net.exe session 1>nul 2>&1 || (
-    call :print_error_message Cannot run scenariobenchmark test because this is not an administrator window
-    exit /b 1
-  )
 
-  for %%v in (1.0 1.1 2.0) do (
-    dotnet.exe publish -c %BuildConfiguration% --framework netcoreapp%%v                                                                                            || exit /b 1
-    dotnet.exe "bin\%BuildConfiguration%\netcoreapp%%v\scenariobenchmark.dll" --perf:collect default --perf:outputdir "%CD%\bin\%BuildConfiguration%\netcoreapp%%v" || exit /b 1
+  for %%v in (netcoreapp1.0 netcoreapp1.1 netcoreapp2.0 net461) do (
+    dotnet.exe publish -c %BuildConfiguration% --framework "%%v"                          || exit /b 1
+    pushd ".\bin\%BuildConfiguration%\%%v\publish"
+    if "%%v" == "net461" (
+      ".\scenariobenchmark.exe"            --perf:collect default --perf:outputdir "!cd!" || exit /b 1
+    ) else (
+      dotnet.exe ".\scenariobenchmark.dll" --perf:collect default --perf:outputdir "!cd!" || exit /b 1
+    )
+    popd
   )
 
   exit /b %errorlevel%

--- a/dotnet-install.cmd
+++ b/dotnet-install.cmd
@@ -3,6 +3,8 @@
 
 :install_dotnet_cli
 setlocal
+  set "DOTNET_MULTILEVEL_LOOKUP=0"
+
   set /p DotNet_Version=<"%~dp0DotNetCLIVersion.txt"
   if not defined DotNet_Version (
     call :print_error_message Unknown DotNet CLI Version.

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -432,7 +432,8 @@ namespace Microsoft.Xunit.Performance.Api
             BenchmarkEventSource.Log.Close();
 
             // Deleting raw data not used by api users.
-            File.Delete(Configuration.FileLogPath);
+            if (File.Exists(Configuration.FileLogPath))
+                File.Delete(Configuration.FileLogPath);
         }
 
         #endregion IDisposable implementation

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.api</AssemblyTitle>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
     <Title>xUnit Performance Api</Title>
     <RootNamespace>Microsoft.Xunit.Performance.Api</RootNamespace>
   </PropertyGroup>

--- a/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
+++ b/src/xunit.performance.execution/AllocatedBytesForCurrentThread.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xunit.Performance.Execution
             {
                 _GetAllocatedBytesForCurrentThread = () => -0xBAAAAAAD;
                 IsAvailable = false;
-                NoAvailabilityReason = "The running implementation netcoreapp does not expose 'GC.GetAllocatedBytesForCurrentThread'.";
+                NoAvailabilityReason = "The running implementation of .NET does not expose 'GC.GetAllocatedBytesForCurrentThread'.";
             }
             else
             {

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.execution</AssemblyTitle>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
     <Title>xUnit Performance Execution</Title>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.metrics</AssemblyTitle>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
     <Title>xUnit Performance Metrics</Title>
   </PropertyGroup>
 

--- a/tests/scenariobenchmark/Program.cs
+++ b/tests/scenariobenchmark/Program.cs
@@ -69,6 +69,7 @@ namespace simpleharness
 
             processToMeasure.RedirectStandardError = true;
             processToMeasure.RedirectStandardOutput = true;
+            processToMeasure.UseShellExecute = false;
 
             var scenarioTestConfiguration = new ScenarioTestConfiguration(Timeout, processToMeasure) {
                 Iterations = Iterations,

--- a/tests/scenariobenchmark/scenariobenchmark.csproj
+++ b/tests/scenariobenchmark/scenariobenchmark.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -14,7 +14,7 @@ namespace simpleharness
     [MeasureGCAllocations]
     public class Program
     {
-        public static void Main(string[] args)
+        static void Main(string[] args)
         {
             using (var p = new XunitPerformanceHarness(args))
             {

--- a/tests/simpleharness/simpleharness.csproj
+++ b/tests/simpleharness/simpleharness.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/standalonesample/standalonesample.csproj
+++ b/tests/standalonesample/standalonesample.csproj
@@ -6,14 +6,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.3-alpha-experimental">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.performance.api" Version="1.0.0-beta-build0007" />
+    <PackageReference Include="xunit.performance.api" Version="1.0.0-beta-build0013" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Our packages were targeting netstandard1.5, but they are not working when targeting desktop. While we are investigating, I'm adding to the build matrix net461 to unblock desktop perf investigations.