### PR TITLE
Minor changes and bug fixes.

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0014
+  set VersionSuffix=beta-build0015
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/Profilers/ETWProfiler.cs
+++ b/src/xunit.performance.api/Profilers/ETWProfiler.cs
@@ -260,8 +260,9 @@ namespace Microsoft.Xunit.Performance.Api
         [Conditional("DEBUG")]
         private static void GetRegisteredProvidersInProcess()
         {
-            new List<string>(TraceEventProviders.GetRegisteredProvidersInProcess(System.Diagnostics.Process.GetCurrentProcess().Id)
-                .Select(p => TraceEventProviders.GetProviderName(p))).ForEach(name => Debug.WriteLine(name));
+            TraceEventProviders.GetRegisteredProvidersInProcess(System.Diagnostics.Process.GetCurrentProcess().Id)
+                .Select(p => TraceEventProviders.GetProviderName(p))
+                .ForEach(name => Debug.WriteLine(name));
         }
     }
 }

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -68,7 +68,9 @@ namespace Microsoft.Xunit.Performance.Api
 
             void xUnitAction(string assemblyPath)
             {
-                XunitRunner.Run(assemblyPath, _typeNames);
+                var errCode = XunitRunner.Run(assemblyPath, _typeNames);
+                if (errCode != 0)
+                    throw new Exception($"{errCode} benchmark(s) did not complete successfully.");
             }
 
             var xUnitPerformanceSessionData = new XUnitPerformanceSessionData {

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Xunit.Performance.Api
             {
                 var errCode = XunitRunner.Run(assemblyPath, _typeNames);
                 if (errCode != 0)
-                    throw new Exception($"{errCode} benchmark(s) did not complete successfully.");
+                    throw new Exception($"{errCode} benchmark(s) failed to execute.");
             }
 
             var xUnitPerformanceSessionData = new XUnitPerformanceSessionData {

--- a/tests/simpleharness/GetAllocatedBytesForCurrentThreadTest.cs
+++ b/tests/simpleharness/GetAllocatedBytesForCurrentThreadTest.cs
@@ -6,6 +6,7 @@ namespace simpleharness
 {
     public class GetAllocatedBytesForCurrentThreadTest
     {
+#if NETCOREAPP1_1 || NETCOREAPP2_0
         [Benchmark]
         public static void WithCollect()
         {
@@ -60,5 +61,6 @@ namespace simpleharness
                 }
             });
         }
+#endif
     }
 }

--- a/tests/simpleharness/Program.cs
+++ b/tests/simpleharness/Program.cs
@@ -48,6 +48,23 @@ namespace simpleharness
             }
         }
 
+        [MeasureGCCounts]
+        [Benchmark(InnerIterationCount = 10, Skip = "This is a duplicated benchmark that needs to be skipped.")]
+        [MemberData(nameof(InputData))]
+        public static void TestMultipleStringInputs2(string[] args)
+        {
+            foreach (BenchmarkIteration iter in Benchmark.Iterations)
+            {
+                using (iter.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        FormattedString(args[0], args[0], args[0], args[0]);
+                    }
+                }
+            }
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static string FormattedString(string a, string b, string c, string d)
         {


### PR DESCRIPTION
- After running all benchmarks now we throw an exception if a benchmark failed.
  - This is mainly meant to catch bad code gen or broken benchmarks on automation.
- Add an example where a Benchmark attribute is marked to be skipped. 
- Disable the GetAllocatedBytesForCurrentThreadTest on non-netcoreapp[1.1|2.0]
- Updating some error message strings. 
- Simplified a DEBUG ONLY function.
