### PR TITLE
Update xUnit and CommandLineParser NuGet packages to stable versions

### DIFF
--- a/src/version.props
+++ b/src/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <MicrosoftDiagnosticsTracingLibraryVersion>1.0.3-alpha-experimental</MicrosoftDiagnosticsTracingLibraryVersion>
-    <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
+    <XunitPackageVersion>2.2.0</XunitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
+++ b/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
@@ -11,12 +11,23 @@ namespace Microsoft.Xunit.Performance.Api
     /// This is the message sink that receives IDiagnosticMessage messages from
     /// the XunitFrontController.
     /// </summary>
-    internal sealed class ConsoleDiagnosticMessageSink : TestMessageVisitor<IDiagnosticMessage>
+    internal sealed class ConsoleDiagnosticMessageSink : TestMessageSink
     {
-        protected override bool Visit(IDiagnosticMessage diagnosticMessage)
+        public ConsoleDiagnosticMessageSink()
         {
-            WriteErrorLine(diagnosticMessage.Message);
-            return true;
+            Diagnostics.DiagnosticMessageEvent += OnDiagnosticMessageEvent;
+        }
+
+        private static void OnDiagnosticMessageEvent(MessageHandlerArgs<IDiagnosticMessage> args)
+        {
+            WriteErrorLine(args.Message.Message);
+        }
+
+        public override void Dispose()
+        {
+            Diagnostics.DiagnosticMessageEvent -= OnDiagnosticMessageEvent;
+
+            base.Dispose();
         }
     }
 }

--- a/src/xunit.performance.api/PerformanceTestMessageSink.cs
+++ b/src/xunit.performance.api/PerformanceTestMessageSink.cs
@@ -11,10 +11,9 @@ namespace Microsoft.Xunit.Performance.Api
 {
     internal sealed class PerformanceTestMessageSink : TestMessageSink
     {
-        private readonly ManualResetEvent _finished = new ManualResetEvent(false);
-
         public PerformanceTestMessageSink()
         {
+            Finished = new ManualResetEvent(false);
             Tests = new List<PerformanceTestMessage>();
             Discovery.TestCaseDiscoveryMessageEvent += OnTestCaseDiscoveryMessageEvent;
             Discovery.DiscoveryCompleteMessageEvent += OnDiscoveryCompleteMessageEvent;
@@ -52,7 +51,7 @@ namespace Microsoft.Xunit.Performance.Api
 
         private void OnDiscoveryCompleteMessageEvent(MessageHandlerArgs<IDiscoveryCompleteMessage> args)
         {
-            _finished.Set();
+            Finished.Set();
         }
 
         private static IEnumerable<IAttributeInfo> GetMetricAttributes(ITestMethod testMethod)
@@ -96,6 +95,6 @@ namespace Microsoft.Xunit.Performance.Api
             base.Dispose();
         }
 
-        public ManualResetEvent Finished => _finished;
+        public ManualResetEvent Finished { get; }
     }
 }

--- a/src/xunit.performance.api/XunitBenchmark.cs
+++ b/src/xunit.performance.api/XunitBenchmark.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Xunit.Performance.Api
                         includeSourceInformation: false,
                         messageSink: testMessageSink,
                         discoveryOptions: TestFrameworkOptions.ForDiscovery());
+                    testMessageSink.Finished.WaitOne();
 
                     var testProviders =
                         from test in testMessageSink.Tests

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingLibraryVersion)">
       <IncludeAssets>All</IncludeAssets>


### PR DESCRIPTION
- Update xUnit packages to version 2.2.0
- Update CommandLineParser package to version 2.2.1