### PR TITLE
Upgrade to TraceEvent 2.0.5

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0016
+  set VersionSuffix=beta-build0017
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides extensions over xUnit to author performance tests.
 
 1. Create a new class library project
 2. Add a reference to the latest [xunit.performance.api.dll](https://dotnet.myget.org/feed/dotnet-core/package/nuget/xunit.performance.api)
-3. Add a reference to the latest [Microsoft.Diagnostics.Tracing.TraceEvent](https://dotnet.myget.org/feed/dotnet-core/package/nuget/Microsoft.Diagnostics.Tracing.TraceEvent)
+3. Add a reference to the latest [Microsoft.Diagnostics.Tracing.TraceEvent](https://www.nuget.org/packages/Microsoft.Diagnostics.Tracing.TraceEvent)
     (It deploys native libraries needed to merge the \*.etl files)
 4. Tag your test methods with [Benchmark] instead of [Fact]
 5. Make sure that each [Benchmark]-annotated test contains a loop of this form:

--- a/src/version.props
+++ b/src/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftDiagnosticsTracingLibraryVersion>1.0.3-alpha-experimental</MicrosoftDiagnosticsTracingLibraryVersion>
+    <MicrosoftDiagnosticsTracingLibraryVersion>2.0.4</MicrosoftDiagnosticsTracingLibraryVersion>
     <XunitPackageVersion>2.2.0</XunitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/version.props
+++ b/src/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <MicrosoftDiagnosticsTracingLibraryVersion>2.0.4</MicrosoftDiagnosticsTracingLibraryVersion>
+    <MicrosoftDiagnosticsTracingLibraryVersion>2.0.5</MicrosoftDiagnosticsTracingLibraryVersion>
     <XunitPackageVersion>2.2.0</XunitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.api</AssemblyTitle>
-    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.5</TargetFrameworks>
     <Title>xUnit Performance Api</Title>
     <RootNamespace>Microsoft.Xunit.Performance.Api</RootNamespace>
@@ -18,6 +18,7 @@
     </PackageReference>
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="xunit.runner.utility" Version="$(XunitPackageVersion)" />
   </ItemGroup>
 

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.api</AssemblyTitle>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.5</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.6</TargetFrameworks>
     <Title>xUnit Performance Api</Title>
     <RootNamespace>Microsoft.Xunit.Performance.Api</RootNamespace>
   </PropertyGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.metrics</AssemblyTitle>
-    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.5</TargetFrameworks>
     <Title>xUnit Performance Metrics</Title>
   </PropertyGroup>

--- a/src/xunit.performance.metrics/xunit.performance.metrics.csproj
+++ b/src/xunit.performance.metrics/xunit.performance.metrics.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.metrics</AssemblyTitle>
     <TargetFrameworks>netstandard1.6;net461</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.5</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.6</TargetFrameworks>
     <Title>xUnit Performance Metrics</Title>
   </PropertyGroup>
 

--- a/tests/standalonesample/standalonesample.csproj
+++ b/tests/standalonesample/standalonesample.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.3-alpha-experimental">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.4">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.performance.api" Version="1.0.0-beta-build0015" />

--- a/tests/standalonesample/standalonesample.csproj
+++ b/tests/standalonesample/standalonesample.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.4">
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.5">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.performance.api" Version="1.0.0-beta-build0015" />


### PR DESCRIPTION
Updated: This PR updates xunit-performance to use TraceEvent 2.0.5 which contains the fixes necessary to run against netstandard1.6.

------------------------------
OLD:

In order to move off of the pre-release version of TraceEvent to a shipped version (2.0.4) we need to do two this:

1. Update the nuget package reference to 2.0.4.
2. Remove support for netcoreapp1.0 and 1.1.

Older versions of the harness can still run on netcoreapp1.0 and 1.1, but the official TraceEvent package does not support versions of netcoreapp older than 2.0.  This is because there are some support DLLs that won't run on previous versions without a decent amount of work.  They work on 2.0 because enough type-forwarders have been added to mscorlib to handle the work that these DLLs do, but these type-forwarders don't exist pre-netcoreapp2.0.

Per my conversation with @valenis, we do not need to continue to produce new harnesses that support pre-netcoreapp2.0, and thus rather than attempting to do the work to make the new version of TraceEvent support netcoreapp1.0 and 1.1, we can drop support for them here.