### PR TITLE
Downgrade XUnit-Performance Dependencies

### DIFF
--- a/src/version.props
+++ b/src/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <MicrosoftDiagnosticsTracingLibraryVersion>2.0.5</MicrosoftDiagnosticsTracingLibraryVersion>
-    <XunitPackageVersion>2.2.0</XunitPackageVersion>
+    <XunitPackageVersion>2.2.0-beta2-build3300</XunitPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
+++ b/src/xunit.performance.api/ConsoleDiagnosticMessageSink.cs
@@ -11,23 +11,12 @@ namespace Microsoft.Xunit.Performance.Api
     /// This is the message sink that receives IDiagnosticMessage messages from
     /// the XunitFrontController.
     /// </summary>
-    internal sealed class ConsoleDiagnosticMessageSink : TestMessageSink
+    internal sealed class ConsoleDiagnosticMessageSink : TestMessageVisitor<IDiagnosticMessage>
     {
-        public ConsoleDiagnosticMessageSink()
+        protected override bool Visit(IDiagnosticMessage diagnosticMessage)
         {
-            Diagnostics.DiagnosticMessageEvent += OnDiagnosticMessageEvent;
-        }
-
-        private static void OnDiagnosticMessageEvent(MessageHandlerArgs<IDiagnosticMessage> args)
-        {
-            WriteErrorLine(args.Message.Message);
-        }
-
-        public override void Dispose()
-        {
-            Diagnostics.DiagnosticMessageEvent -= OnDiagnosticMessageEvent;
-
-            base.Dispose();
+            WriteErrorLine(diagnosticMessage.Message);
+            return true;
         }
     }
 }

--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.2.1" />
+    <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
     <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingLibraryVersion)">
       <IncludeAssets>All</IncludeAssets>


### PR DESCRIPTION
Reverts commit 03e7799c6b8bfdb01c168f1e737adb085cb93938.

XUnit-Performance must maintain the same dependencies are CoreFX in order to ensure that there are not conflicts.  CoreFX is unique as it does not support ProjectReferences (and thus specifying unique references per component).