### PR TITLE
Double the default Etw buffer size to 512MB

### DIFF
--- a/BuildForPublication.cmd
+++ b/BuildForPublication.cmd
@@ -5,7 +5,7 @@
 setlocal EnableDelayedExpansion
   set errorlevel=
   set BuildConfiguration=Release
-  set VersionSuffix=beta-build0018
+  set VersionSuffix=beta-build0019
 
   REM Check that git is on path.
   where.exe /Q git.exe || (

--- a/src/xunit.performance.api/Profilers/ETWProfiler.cs
+++ b/src/xunit.performance.api/Profilers/ETWProfiler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Xunit.Performance.Api
         /// <param name="action"></param>
         public static void Record(XUnitPerformanceSessionData xUnitPerformanceSessionData, XUnitPerformanceMetricData xUnitPerformanceMetricData, Action action)
         {
-            const int bufferSizeMB = 256;
+            const int bufferSizeMB = 512;
             var name = $"{xUnitPerformanceSessionData.RunId}-{Path.GetFileNameWithoutExtension(xUnitPerformanceSessionData.AssemblyFileName)}";
             var etwOutputData = new ETWOutputData {
                 KernelFileName = Path.Combine(xUnitPerformanceSessionData.OutputDirectory, $"{name}.kernel.etl"), // without this parameter, EnableKernelProvider will fail

--- a/src/xunit.performance.api/XunitPerformanceHarness.cs
+++ b/src/xunit.performance.api/XunitPerformanceHarness.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Xunit.Performance.Api
                         Helper.SetPreciseMachineCounters(profileSourceInfos.ToList());
 
                         var listener = new Listener<ScenarioExecutionResult>(
-                            new SessionData(sessionName, etlFileName) { BufferSizeMB = 256 },
+                            new SessionData(sessionName, etlFileName) { BufferSizeMB = 512 },
                             UserProvider.Defaults,
                             kernelProviders.ToList());
 


### PR DESCRIPTION
The CoreFx concurrent tests are intermittently failing due to lost events. These change should aliviate the failures.

