### PR TITLE
Remove unstable package & cross compile executor

### DIFF
--- a/src/xunit.performance.api/xunit.performance.api.csproj
+++ b/src/xunit.performance.api/xunit.performance.api.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser.NS20" Version="2.3.1" />
-    <PackageReference Include="Microsoft.3rdpartytools.MarkdownLog" Version="0.10.0-alpha-experimental" />
+    <PackageReference Include="MarkdownLog.NS20" Version="0.10.1" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="$(MicrosoftDiagnosticsTracingLibraryVersion)">
       <IncludeAssets>All</IncludeAssets>
     </PackageReference>

--- a/src/xunit.performance.execution/xunit.performance.execution.csproj
+++ b/src/xunit.performance.execution/xunit.performance.execution.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>xunit.performance.execution</AssemblyTitle>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp2.0</TargetFrameworks>
     <Title>xUnit Performance Execution</Title>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
@jorive this fixes the test error and also replaces the alpha dependency with a stable netstandard2.0 package. This removes a compiler warnings because of two different assembly identities. I also opened a PR but I doubt it will be accepted as the project seems dead: https://github.com/Wheelies/MarkdownLog/pull/16

You can now publish the packages. Thanks!